### PR TITLE
Add ignoreCache to Executable

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -9,8 +9,8 @@ class Executable {
   const Executable(this.cmd);
 
   /// Asynchronously finds the path to the executable [cmd].
-  Future<String?> find() async {
-    if (_whichResults.containsKey(cmd)) {
+  Future<String?> find({bool ignoreCache = false}) async {
+    if (!ignoreCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
     final result = await which(cmd);
@@ -19,11 +19,12 @@ class Executable {
   }
 
   /// Asynchronously checks if the executable [cmd] exists.
-  Future<bool> exists() async => await find() != null;
+  Future<bool> exists({bool ignoreCache = false}) async =>
+      await find(ignoreCache: ignoreCache) != null;
 
   /// Synchronously finds the path to the executable [cmd].
-  String? findSync() {
-    if (_whichResults.containsKey(cmd)) {
+  String? findSync({bool ignoreCache = false}) {
+    if (!ignoreCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
     final result = whichSync(cmd);
@@ -32,5 +33,6 @@ class Executable {
   }
 
   /// Synchronously checks if the executable [cmd] exists.
-  bool existsSync() => findSync() != null;
+  bool existsSync({bool ignoreCache = false}) =>
+      findSync(ignoreCache: ignoreCache) != null;
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -13,4 +13,16 @@ void main() {
     final result = await ls.find();
     expect(result, isNotNull);
   });
+
+  test('Test ignore cache', () async {
+    final ls = Executable('ls');
+    final result = await ls.find(ignoreCache: true);
+    expect(result, isNotNull);
+    final exists = await ls.exists(ignoreCache: true);
+    expect(exists, true);
+    final resultSync = ls.findSync(ignoreCache: true);
+    expect(resultSync, isNotNull);
+    final existsSync = ls.existsSync(ignoreCache: true);
+    expect(existsSync, true);
+  });
 }


### PR DESCRIPTION
Added `ignoreCache` parameter to `find`, `findSync`, `exists`, and `existsSync` methods in `Executable` class.
Updated tests to verify the new parameter.

---
*PR created automatically by Jules for task [1693815417272404789](https://jules.google.com/task/1693815417272404789) started by @insign*