### PR TITLE
Add ignoreCache to Executable methods

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -9,8 +9,8 @@ class Executable {
   const Executable(this.cmd);
 
   /// Asynchronously finds the path to the executable [cmd].
-  Future<String?> find() async {
-    if (_whichResults.containsKey(cmd)) {
+  Future<String?> find({bool ignoreCache = false}) async {
+    if (!ignoreCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
     final result = await which(cmd);
@@ -19,11 +19,12 @@ class Executable {
   }
 
   /// Asynchronously checks if the executable [cmd] exists.
-  Future<bool> exists() async => await find() != null;
+  Future<bool> exists({bool ignoreCache = false}) async =>
+      await find(ignoreCache: ignoreCache) != null;
 
   /// Synchronously finds the path to the executable [cmd].
-  String? findSync() {
-    if (_whichResults.containsKey(cmd)) {
+  String? findSync({bool ignoreCache = false}) {
+    if (!ignoreCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
     final result = whichSync(cmd);
@@ -32,5 +33,6 @@ class Executable {
   }
 
   /// Synchronously checks if the executable [cmd] exists.
-  bool existsSync() => findSync() != null;
+  bool existsSync({bool ignoreCache = false}) =>
+      findSync(ignoreCache: ignoreCache) != null;
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -13,4 +13,28 @@ void main() {
     final result = await ls.find();
     expect(result, isNotNull);
   });
+
+  test('Test executable find with ignoreCache', () async {
+    final ls = Executable('ls');
+    final result = await ls.find(ignoreCache: true);
+    expect(result, isNotNull);
+  });
+
+  test('Test executable exists with ignoreCache', () async {
+    final ls = Executable('ls');
+    final result = await ls.exists(ignoreCache: true);
+    expect(result, true);
+  });
+
+  test('Test executable findSync with ignoreCache', () {
+    final ls = Executable('ls');
+    final result = ls.findSync(ignoreCache: true);
+    expect(result, isNotNull);
+  });
+
+  test('Test executable existsSync with ignoreCache', () {
+    final ls = Executable('ls');
+    final result = ls.existsSync(ignoreCache: true);
+    expect(result, true);
+  });
 }


### PR DESCRIPTION
Implemented `ignoreCache` parameter in `Executable` class methods to allow bypassing the internal cache. This is useful when executables might be installed or removed during the application's lifetime. Added corresponding tests.

---
*PR created automatically by Jules for task [534637358013994443](https://jules.google.com/task/534637358013994443) started by @insign*