### PR TITLE
Add ignoreCache parameter to bypass executable lookup cache

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -9,8 +9,10 @@ class Executable {
   const Executable(this.cmd);
 
   /// Asynchronously finds the path to the executable [cmd].
-  Future<String?> find() async {
-    if (_whichResults.containsKey(cmd)) {
+  ///
+  /// If [ignoreCache] is true, the cache is bypassed and the path is resolved again.
+  Future<String?> find({bool ignoreCache = false}) async {
+    if (!ignoreCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
     final result = await which(cmd);
@@ -19,11 +21,16 @@ class Executable {
   }
 
   /// Asynchronously checks if the executable [cmd] exists.
-  Future<bool> exists() async => await find() != null;
+  ///
+  /// If [ignoreCache] is true, the cache is bypassed and the existence is checked again.
+  Future<bool> exists({bool ignoreCache = false}) async =>
+      await find(ignoreCache: ignoreCache) != null;
 
   /// Synchronously finds the path to the executable [cmd].
-  String? findSync() {
-    if (_whichResults.containsKey(cmd)) {
+  ///
+  /// If [ignoreCache] is true, the cache is bypassed and the path is resolved again.
+  String? findSync({bool ignoreCache = false}) {
+    if (!ignoreCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
     final result = whichSync(cmd);
@@ -32,5 +39,8 @@ class Executable {
   }
 
   /// Synchronously checks if the executable [cmd] exists.
-  bool existsSync() => findSync() != null;
+  ///
+  /// If [ignoreCache] is true, the cache is bypassed and the existence is checked again.
+  bool existsSync({bool ignoreCache = false}) =>
+      findSync(ignoreCache: ignoreCache) != null;
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -13,4 +13,28 @@ void main() {
     final result = await ls.find();
     expect(result, isNotNull);
   });
+
+  test('Test executable existence with ignoreCache', () async {
+    final ls = Executable('ls');
+    final result = await ls.exists(ignoreCache: true);
+    expect(result, true);
+  });
+
+  test('Test executable path with ignoreCache', () async {
+    final ls = Executable('ls');
+    final result = await ls.find(ignoreCache: true);
+    expect(result, isNotNull);
+  });
+
+  test('Test sync executable existence with ignoreCache', () {
+    final ls = Executable('ls');
+    final result = ls.existsSync(ignoreCache: true);
+    expect(result, true);
+  });
+
+  test('Test sync executable path with ignoreCache', () {
+    final ls = Executable('ls');
+    final result = ls.findSync(ignoreCache: true);
+    expect(result, isNotNull);
+  });
 }


### PR DESCRIPTION
Added an optional `ignoreCache` parameter to `find`, `exists`, `findSync`, and `existsSync` methods in `Executable` class. This allows bypassing the static cache and re-checking the executable path, which is useful for long-running applications where the environment might change. Updated tests to include verification of the new parameter.

---
*PR created automatically by Jules for task [14474252586013141709](https://jules.google.com/task/14474252586013141709) started by @insign*