### PR TITLE
Add ignoreCache to Executable class

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -9,8 +9,10 @@ class Executable {
   const Executable(this.cmd);
 
   /// Asynchronously finds the path to the executable [cmd].
-  Future<String?> find() async {
-    if (_whichResults.containsKey(cmd)) {
+  ///
+  /// If [ignoreCache] is true, the cache is ignored and the path is searched again.
+  Future<String?> find({bool ignoreCache = false}) async {
+    if (!ignoreCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
     final result = await which(cmd);
@@ -19,11 +21,16 @@ class Executable {
   }
 
   /// Asynchronously checks if the executable [cmd] exists.
-  Future<bool> exists() async => await find() != null;
+  ///
+  /// If [ignoreCache] is true, the cache is ignored and the path is searched again.
+  Future<bool> exists({bool ignoreCache = false}) async =>
+      await find(ignoreCache: ignoreCache) != null;
 
   /// Synchronously finds the path to the executable [cmd].
-  String? findSync() {
-    if (_whichResults.containsKey(cmd)) {
+  ///
+  /// If [ignoreCache] is true, the cache is ignored and the path is searched again.
+  String? findSync({bool ignoreCache = false}) {
+    if (!ignoreCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
     final result = whichSync(cmd);
@@ -32,5 +39,8 @@ class Executable {
   }
 
   /// Synchronously checks if the executable [cmd] exists.
-  bool existsSync() => findSync() != null;
+  ///
+  /// If [ignoreCache] is true, the cache is ignored and the path is searched again.
+  bool existsSync({bool ignoreCache = false}) =>
+      findSync(ignoreCache: ignoreCache) != null;
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -13,4 +13,28 @@ void main() {
     final result = await ls.find();
     expect(result, isNotNull);
   });
+
+  test('Test executable existence with ignoreCache', () async {
+    final ls = Executable('ls');
+    final result = await ls.exists(ignoreCache: true);
+    expect(result, true);
+  });
+
+  test('Test executable path with ignoreCache', () async {
+    final ls = Executable('ls');
+    final result = await ls.find(ignoreCache: true);
+    expect(result, isNotNull);
+  });
+
+  test('Test synchronous executable existence with ignoreCache', () {
+    final ls = Executable('ls');
+    final result = ls.existsSync(ignoreCache: true);
+    expect(result, true);
+  });
+
+  test('Test synchronous executable path with ignoreCache', () {
+    final ls = Executable('ls');
+    final result = ls.findSync(ignoreCache: true);
+    expect(result, isNotNull);
+  });
 }


### PR DESCRIPTION
Added `ignoreCache` optional parameter to `find`, `exists`, `findSync`, and `existsSync` methods in `Executable` class.
This parameter allows forcing a fresh lookup of the executable path, bypassing the static cache.
Added tests to verify the new parameter usage.

---
*PR created automatically by Jules for task [8234609178545810509](https://jules.google.com/task/8234609178545810509) started by @insign*