### PR TITLE
feat: add ignoreCache parameter to Executable methods

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -9,8 +9,8 @@ class Executable {
   const Executable(this.cmd);
 
   /// Asynchronously finds the path to the executable [cmd].
-  Future<String?> find() async {
-    if (_whichResults.containsKey(cmd)) {
+  Future<String?> find({bool ignoreCache = false}) async {
+    if (!ignoreCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
     final result = await which(cmd);
@@ -19,11 +19,12 @@ class Executable {
   }
 
   /// Asynchronously checks if the executable [cmd] exists.
-  Future<bool> exists() async => await find() != null;
+  Future<bool> exists({bool ignoreCache = false}) async =>
+      await find(ignoreCache: ignoreCache) != null;
 
   /// Synchronously finds the path to the executable [cmd].
-  String? findSync() {
-    if (_whichResults.containsKey(cmd)) {
+  String? findSync({bool ignoreCache = false}) {
+    if (!ignoreCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
     final result = whichSync(cmd);
@@ -32,5 +33,6 @@ class Executable {
   }
 
   /// Synchronously checks if the executable [cmd] exists.
-  bool existsSync() => findSync() != null;
+  bool existsSync({bool ignoreCache = false}) =>
+      findSync(ignoreCache: ignoreCache) != null;
 }

--- a/test/ignore_cache_runner.dart
+++ b/test/ignore_cache_runner.dart
@@ -1,0 +1,81 @@
+import 'dart:io';
+import 'package:executable/executable.dart';
+
+void main(List<String> args) async {
+  if (args.isEmpty) {
+    print('Usage: ignore_cache_runner <cmd>');
+    exit(1);
+  }
+  final cmd = args[0];
+  final exe = Executable(cmd);
+
+  // 1. Find the executable (should be found)
+  var path = await exe.find();
+  if (path == null) {
+    print('Error: Executable $cmd not found initially.');
+    exit(1);
+  }
+  print('Found at: $path');
+
+  // 2. Delete the executable
+  final file = File(path);
+  if (await file.exists()) {
+    await file.delete();
+    print('Deleted $path');
+  } else {
+    print('Error: File $path does not exist.');
+    exit(1);
+  }
+
+  // 3. Find again (should be found due to cache)
+  var cachedPath = await exe.find();
+  if (cachedPath != path) {
+    print('Error: Cache miss. Expected $path, got $cachedPath');
+    exit(1);
+  }
+  print('Cache hit: $cachedPath');
+
+  // 4. Find with ignoreCache: true (should NOT be found)
+  var newPath = await exe.find(ignoreCache: true);
+  if (newPath != null) {
+    print('Error: Cache bypass failed. Expected null, got $newPath');
+    exit(1);
+  }
+  print('Cache bypassed successfully. Result is null.');
+
+  // Re-create file for Sync test
+  await file.writeAsString('#!/bin/sh\necho hello');
+  if (!Platform.isWindows) {
+    await Process.run('chmod', ['+x', file.path]);
+  }
+
+  // 5. Test Sync methods
+  // Note: Previous async find(ignoreCache: true) updated the cache to null!
+  // So findSync() should return null if it uses the same cache.
+  // Yes, _whichResults is static.
+
+  // So we first need to re-populate cache.
+  var syncPath = exe.findSync(ignoreCache: true);
+  if (syncPath == null) {
+    print('Error: Sync find failed after recreation.');
+    exit(1);
+  }
+
+  await file.delete();
+
+  // Sync find cache (should be hit)
+  var syncCache = exe.findSync();
+  if (syncCache != syncPath) {
+    print('Error: Sync cache miss.');
+    exit(1);
+  }
+
+  // Sync ignore cache (should be null)
+  var syncIgnore = exe.findSync(ignoreCache: true);
+  if (syncIgnore != null) {
+    print('Error: Sync ignore cache failed.');
+    exit(1);
+  }
+
+  print('All checks passed.');
+}

--- a/test/ignore_cache_test.dart
+++ b/test/ignore_cache_test.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+import 'package:test/test.dart';
+
+void main() {
+  test('Test executable cache ignore', () async {
+    // Create a temporary directory
+    final tempDir = await Directory.systemTemp.createTemp('executable_test_');
+    addTearDown(() => tempDir.delete(recursive: true));
+
+    var cmdName = 'test_executable_ignore_cache';
+    if (Platform.isWindows) {
+      cmdName += '.bat';
+    }
+
+    final exePath = '${tempDir.path}${Platform.pathSeparator}$cmdName';
+
+    // Create dummy executable
+    final file = File(exePath);
+    if (Platform.isWindows) {
+      await file.writeAsString('@echo off\necho hello');
+    } else {
+      await file.writeAsString('#!/bin/sh\necho hello');
+      await Process.run('chmod', ['+x', exePath]);
+    }
+
+    // Run the runner script with updated PATH
+    final separator = Platform.isWindows ? ';' : ':';
+    final envPath = Platform.environment['PATH'] ?? '';
+    final newPath = '${tempDir.path}$separator$envPath';
+
+    // On Windows, 'which' finds the command even without extension if it matches known extensions.
+    // We pass the name without extension to verify typical usage.
+    final cmdArg = 'test_executable_ignore_cache';
+
+    final result = await Process.run(
+      'dart',
+      ['run', 'test/ignore_cache_runner.dart', cmdArg],
+      environment: {...Platform.environment, 'PATH': newPath},
+    );
+
+    if (result.exitCode != 0) {
+      print('Runner stdout: ${result.stdout}');
+      print('Runner stderr: ${result.stderr}');
+    }
+
+    expect(result.exitCode, 0, reason: 'Runner failed.');
+  });
+}


### PR DESCRIPTION
Added `ignoreCache` parameter to `Executable` methods (`find`, `findSync`, `exists`, `existsSync`) to allow bypassing the internal static cache. This is useful for scenarios where executables might be installed or moved during the application's lifetime.
Added comprehensive tests using a subprocess to verify that the cache is correctly bypassed when requested.

---
*PR created automatically by Jules for task [5623141582133732652](https://jules.google.com/task/5623141582133732652) started by @insign*