### PR TITLE
Support full and relative paths in Executable lookup

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -8,12 +10,29 @@ class Executable {
   /// Constructs a new `Executable` instance with the given [cmd].
   const Executable(this.cmd);
 
+  bool get _isPath =>
+      cmd.contains('/') || (Platform.isWindows && cmd.contains('\\'));
+
   /// Asynchronously finds the path to the executable [cmd].
   Future<String?> find({bool ignoreCache = false}) async {
     if (!ignoreCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
-    final result = await which(cmd);
+
+    String? result;
+    if (_isPath) {
+      final file = File(cmd);
+      if (await file.exists()) {
+        if (Platform.isWindows) {
+          if (_isWindowsExecutable(cmd)) result = file.absolute.path;
+        } else {
+          if (await _isPosixExecutable(file)) result = file.absolute.path;
+        }
+      }
+    }
+
+    result ??= await which(cmd);
+
     _whichResults[cmd] = result;
     return result;
   }
@@ -27,7 +46,21 @@ class Executable {
     if (!ignoreCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
-    final result = whichSync(cmd);
+
+    String? result;
+    if (_isPath) {
+      final file = File(cmd);
+      if (file.existsSync()) {
+        if (Platform.isWindows) {
+          if (_isWindowsExecutable(cmd)) result = file.absolute.path;
+        } else {
+          if (_isPosixExecutableSync(file)) result = file.absolute.path;
+        }
+      }
+    }
+
+    result ??= whichSync(cmd);
+
     _whichResults[cmd] = result;
     return result;
   }
@@ -35,4 +68,23 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  bool _isWindowsExecutable(String path) {
+    // PATHEXT defaults to .COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC
+    final pathExt = Platform.environment['PATHEXT'] ?? '.EXE;.BAT;.CMD;.COM';
+    final exts = pathExt.split(';').where((e) => e.isNotEmpty).toList();
+    final upperPath = path.toUpperCase();
+    return exts.any((ext) => upperPath.endsWith(ext.toUpperCase()));
+  }
+
+  Future<bool> _isPosixExecutable(File file) async {
+    final stat = await file.stat();
+    // 0x1 (other x) | 0x8 (group x) | 0x40 (owner x) -> 0x49
+    return (stat.mode & 0x49) != 0;
+  }
+
+  bool _isPosixExecutableSync(File file) {
+    final stat = file.statSync();
+    return (stat.mode & 0x49) != 0;
+  }
 }

--- a/test/executable_full_path_test.dart
+++ b/test/executable_full_path_test.dart
@@ -1,0 +1,93 @@
+import 'dart:io';
+import 'package:executable/executable.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Executable with full/relative path', () {
+    late Directory tempDir;
+    late String exePath;
+    late String scriptName;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('executable_test_path_');
+      scriptName = Platform.isWindows ? 'script.bat' : 'script.sh';
+      exePath = '${tempDir.path}${Platform.pathSeparator}$scriptName';
+
+      final file = File(exePath);
+      if (Platform.isWindows) {
+        await file.writeAsString('@echo off\necho hello');
+      } else {
+        await file.writeAsString('#!/bin/sh\necho hello');
+        await Process.run('chmod', ['+x', exePath]);
+      }
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('finds executable by full path', () async {
+      final exe = Executable(exePath);
+      final found = await exe.find();
+      expect(found, isNotNull);
+      // On Windows, paths might differ in case or separators, so normalize if needed?
+      // But find() returns absolute path.
+      expect(found, equals(exePath));
+      expect(await exe.exists(), isTrue);
+    });
+
+    test('findSync finds executable by full path', () {
+      final exe = Executable(exePath);
+      final found = exe.findSync();
+      expect(found, isNotNull);
+      expect(found, equals(exePath));
+      expect(exe.existsSync(), isTrue);
+    });
+
+    test('returns null for non-existing full path', () async {
+      final nonExistent = '${tempDir.path}${Platform.pathSeparator}does_not_exist';
+      final exe = Executable(nonExistent);
+      expect(await exe.find(), isNull);
+      expect(await exe.exists(), isFalse);
+    });
+
+    test('returns null for non-executable file (POSIX only)', () async {
+      if (Platform.isWindows) return; // Windows executable check is complex/extension based
+
+      final nonExePath = '${tempDir.path}/not_executable.txt';
+      await File(nonExePath).writeAsString('content');
+      // Ensure not executable
+      await Process.run('chmod', ['-x', nonExePath]);
+
+      final exe = Executable(nonExePath);
+      expect(await exe.find(), isNull);
+    });
+
+    test('finds executable by relative path', () async {
+      final originalCwd = Directory.current;
+      try {
+        Directory.current = tempDir.path;
+        final relativePath = '.${Platform.pathSeparator}$scriptName';
+        final exe = Executable(relativePath);
+        final found = await exe.find();
+        expect(found, isNotNull);
+        final expected = File(relativePath).absolute.path;
+        expect(File(found!).absolute.path, equals(expected));
+      } finally {
+        Directory.current = originalCwd;
+      }
+    });
+
+    test('returns null for non-executable extension (Windows only)', () async {
+      if (!Platform.isWindows) return;
+
+      final nonExePath = '${tempDir.path}\\not_executable.txt';
+      await File(nonExePath).writeAsString('content');
+
+      final exe = Executable(nonExePath);
+      expect(await exe.find(), isNull);
+    });
+  });
+}


### PR DESCRIPTION
This change improves the `Executable` class by allowing it to find executables specified by a full or relative path (e.g., `./script.sh`, `/usr/bin/tool`), in addition to searching the system PATH. This makes the library more versatile for scenarios where the executable location is known or relative to the current working directory.
Existing `which` functionality is preserved as a fallback for commands without path separators.

---
*PR created automatically by Jules for task [17660334223927704302](https://jules.google.com/task/17660334223927704302) started by @insign*