### PR TITLE
Add run and runSync methods to Executable class

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +38,62 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Asynchronously runs the executable [cmd].
+  ///
+  /// If the executable is not found, throws a [ProcessException].
+  Future<ProcessResult> run(
+    List<String> args, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+  }) async {
+    final path = await find();
+    if (path == null) {
+      throw ProcessException(
+          cmd, args, 'Executable not found in path', -1);
+    }
+    return Process.run(
+      path,
+      args,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
+
+  /// Synchronously runs the executable [cmd].
+  ///
+  /// If the executable is not found, throws a [ProcessException].
+  ProcessResult runSync(
+    List<String> args, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+  }) {
+    final path = findSync();
+    if (path == null) {
+      throw ProcessException(
+          cmd, args, 'Executable not found in path', -1);
+    }
+    return Process.runSync(
+      path,
+      args,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:test/test.dart';
 import 'package:executable/executable.dart';
 
@@ -12,5 +13,31 @@ void main() {
     final ls = Executable('ls');
     final result = await ls.find();
     expect(result, isNotNull);
+  });
+
+  test('Test executable run', () async {
+    final dart = Executable('dart');
+    if (await dart.exists()) {
+      final result = await dart.run(['--version']);
+      expect(result.exitCode, 0);
+    }
+  });
+
+  test('Test executable runSync', () async {
+    final dart = Executable('dart');
+    if (await dart.exists()) {
+      final result = dart.runSync(['--version']);
+      expect(result.exitCode, 0);
+    }
+  });
+
+  test('Test executable run throws', () async {
+    final exe = Executable('non_existent_executable_12345');
+    expect(() => exe.run([]), throwsA(isA<ProcessException>()));
+  });
+
+  test('Test executable runSync throws', () {
+    final exe = Executable('non_existent_executable_12345');
+    expect(() => exe.runSync([]), throwsA(isA<ProcessException>()));
   });
 }


### PR DESCRIPTION
Added `run` and `runSync` methods to `Executable` class to allow executing the found command.
This improves the usability of the package by allowing users to not only find but also run executables.
The methods delegate to `Process.run` and `Process.runSync` respectively.
Updated tests to include verification for these new methods.

---
*PR created automatically by Jules for task [1265237238499440133](https://jules.google.com/task/1265237238499440133) started by @insign*