### PR TITLE
Add execution methods to Executable class

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +38,62 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Asynchronously runs the executable [cmd] with the given [arguments].
+  ///
+  /// Throws a [ProcessException] if the executable is not found.
+  Future<ProcessResult> run(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+    bool ignoreCache = false,
+  }) async {
+    final executablePath = await find(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(cmd, arguments, 'Executable not found', -1);
+    }
+    return Process.run(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
+
+  /// Synchronously runs the executable [cmd] with the given [arguments].
+  ///
+  /// Throws a [ProcessException] if the executable is not found.
+  ProcessResult runSync(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+    bool ignoreCache = false,
+  }) {
+    final executablePath = findSync(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(cmd, arguments, 'Executable not found', -1);
+    }
+    return Process.runSync(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
 }

--- a/test/run_test.dart
+++ b/test/run_test.dart
@@ -1,0 +1,31 @@
+import 'dart:io';
+
+import 'package:executable/executable.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Executable run', () {
+    test('run with existing executable', () async {
+      // Assuming 'dart' is available in the environment as it is running these tests
+      final dart = Executable('dart');
+      final result = await dart.run(['--version']);
+      expect(result.exitCode, 0);
+    });
+
+    test('runSync with existing executable', () {
+      final dart = Executable('dart');
+      final result = dart.runSync(['--version']);
+      expect(result.exitCode, 0);
+    });
+
+    test('run with non-existing executable', () async {
+      final nonExistent = Executable('non_existent_executable_12345');
+      expect(() => nonExistent.run([]), throwsA(isA<ProcessException>()));
+    });
+
+    test('runSync with non-existing executable', () {
+      final nonExistent = Executable('non_existent_executable_12345');
+      expect(() => nonExistent.runSync([]), throwsA(isA<ProcessException>()));
+    });
+  });
+}


### PR DESCRIPTION
Added `run` and `runSync` methods to `Executable` class in `lib/src/executable_base.dart`.
These methods find the executable and run it using `dart:io`'s `Process.run` and `Process.runSync`.
Added `test/run_test.dart` to verify the new functionality.
All tests passed.

---
*PR created automatically by Jules for task [7310476192920588296](https://jules.google.com/task/7310476192920588296) started by @insign*