### PR TITLE
Add run and runSync methods to Executable class

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +38,62 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Asynchronously runs the executable with the given [arguments].
+  ///
+  /// Returns a [ProcessResult] with the result of the execution.
+  /// Throws a [ProcessException] if the executable is not found.
+  Future<ProcessResult> run(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+  }) async {
+    final path = await find();
+    if (path == null) {
+      throw ProcessException(cmd, arguments, 'Executable not found', -1);
+    }
+    return Process.run(
+      path,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
+
+  /// Synchronously runs the executable with the given [arguments].
+  ///
+  /// Returns a [ProcessResult] with the result of the execution.
+  /// Throws a [ProcessException] if the executable is not found.
+  ProcessResult runSync(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+  }) {
+    final path = findSync();
+    if (path == null) {
+      throw ProcessException(cmd, arguments, 'Executable not found', -1);
+    }
+    return Process.runSync(
+      path,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
 }

--- a/test/execution_test.dart
+++ b/test/execution_test.dart
@@ -1,0 +1,38 @@
+import 'dart:io';
+import 'package:executable/executable.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Executable execution', () {
+    test('run executes command', () async {
+      // Use 'dart' executable as it should be available
+      final dart = Executable('dart');
+      final result = await dart.run(['--version']);
+      expect(result.exitCode, 0);
+    });
+
+    test('runSync executes command', () {
+      final dart = Executable('dart');
+      final result = dart.runSync(['--version']);
+      expect(result.exitCode, 0);
+    });
+
+    test('run throws if not found', () async {
+      final notFound = Executable('non_existent_executable_xyz');
+      expect(() => notFound.run([]), throwsA(isA<ProcessException>()));
+    });
+
+    test('runSync throws if not found', () {
+      final notFound = Executable('non_existent_executable_xyz');
+      expect(() => notFound.runSync([]), throwsA(isA<ProcessException>()));
+    });
+
+    test('run supports stdout', () async {
+      final echo = Executable('echo');
+      if (await echo.exists()) {
+        final result = await echo.run(['hello']);
+        expect(result.stdout.toString().trim(), 'hello');
+      }
+    });
+  });
+}


### PR DESCRIPTION
Implemented `run` and `runSync` methods in `Executable` class to allow executing commands. Added tests to verify functionality.

---
*PR created automatically by Jules for task [8102476192038449028](https://jules.google.com/task/8102476192038449028) started by @insign*