### PR TITLE
feat: add run and runSync methods to Executable class

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +38,76 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Asynchronously runs the executable with the given [arguments].
+  ///
+  /// The [ignoreCache] parameter controls whether the path resolution
+  /// ignores the cache.
+  /// Throws a [ProcessException] if the executable is not found.
+  Future<ProcessResult> run(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+    bool ignoreCache = false,
+  }) async {
+    final executablePath = await find(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(
+        cmd,
+        arguments,
+        'Executable not found on system path',
+        2,
+      );
+    }
+    return Process.run(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
+
+  /// Synchronously runs the executable with the given [arguments].
+  ///
+  /// The [ignoreCache] parameter controls whether the path resolution
+  /// ignores the cache.
+  /// Throws a [ProcessException] if the executable is not found.
+  ProcessResult runSync(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+    bool ignoreCache = false,
+  }) {
+    final executablePath = findSync(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(
+        cmd,
+        arguments,
+        'Executable not found on system path',
+        2,
+      );
+    }
+    return Process.runSync(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:test/test.dart';
 import 'package:executable/executable.dart';
 
@@ -12,5 +13,30 @@ void main() {
     final ls = Executable('ls');
     final result = await ls.find();
     expect(result, isNotNull);
+  });
+
+  test('Test run method executes successfully', () async {
+    final dartCmd = Executable('dart');
+    final result = await dartCmd.run(['--version']);
+    expect(result.exitCode, 0);
+  });
+
+  test('Test runSync method executes successfully', () {
+    final dartCmd = Executable('dart');
+    final result = dartCmd.runSync(['--version']);
+    expect(result.exitCode, 0);
+  });
+
+  test('Test run throws ProcessException if not found', () async {
+    final nonExistent = Executable('non_existent_executable_12345');
+    expect(
+      () async => await nonExistent.run([]),
+      throwsA(isA<ProcessException>()),
+    );
+  });
+
+  test('Test runSync throws ProcessException if not found', () {
+    final nonExistent = Executable('non_existent_executable_12345');
+    expect(() => nonExistent.runSync([]), throwsA(isA<ProcessException>()));
   });
 }


### PR DESCRIPTION
This PR introduces `run` and `runSync` methods to the `Executable` class. This enhancement simplifies executing system commands after resolving their paths, and it handles `ProcessException` correctly if the executable is not found. Test coverage has been added.

---
*PR created automatically by Jules for task [2610892359959875251](https://jules.google.com/task/2610892359959875251) started by @insign*