### PR TITLE
Add run methods to Executable class

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+import 'dart:io';
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +37,74 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Asynchronously runs the executable with the given [arguments].
+  ///
+  /// The [ignoreCache] parameter can be used to bypass the executable cache.
+  /// Throws a [ProcessException] if the executable is not found.
+  Future<ProcessResult> run(
+    List<String> arguments, {
+    bool ignoreCache = false,
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+  }) async {
+    final executablePath = await find(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(
+        cmd,
+        arguments,
+        'Executable not found on system.',
+        -1,
+      );
+    }
+    return await Process.run(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
+
+  /// Synchronously runs the executable with the given [arguments].
+  ///
+  /// The [ignoreCache] parameter can be used to bypass the executable cache.
+  /// Throws a [ProcessException] if the executable is not found.
+  ProcessResult runSync(
+    List<String> arguments, {
+    bool ignoreCache = false,
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+  }) {
+    final executablePath = findSync(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(
+        cmd,
+        arguments,
+        'Executable not found on system.',
+        -1,
+      );
+    }
+    return Process.runSync(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:test/test.dart';
 import 'package:executable/executable.dart';
 
@@ -12,5 +13,29 @@ void main() {
     final ls = Executable('ls');
     final result = await ls.find();
     expect(result, isNotNull);
+  });
+
+  test('Test executable run', () async {
+    final echo = Executable('echo');
+    final result = await echo.run(['hello']);
+    expect(result.exitCode, 0);
+    expect(result.stdout.toString().trim(), 'hello');
+  });
+
+  test('Test executable runSync', () {
+    final echo = Executable('echo');
+    final result = echo.runSync(['hello']);
+    expect(result.exitCode, 0);
+    expect(result.stdout.toString().trim(), 'hello');
+  });
+
+  test('Test executable run throws ProcessException', () async {
+    final notFound = Executable('some_non_existent_executable_123');
+    expect(() => notFound.run(['test']), throwsA(isA<ProcessException>()));
+  });
+
+  test('Test executable runSync throws ProcessException', () {
+    final notFound = Executable('some_non_existent_executable_123');
+    expect(() => notFound.runSync(['test']), throwsA(isA<ProcessException>()));
   });
 }


### PR DESCRIPTION
A package that checks for executable paths should naturally allow executing them. This update introduces the `run` and `runSync` wrappers, matching `dart:io` `Process` parameters. Tests were added to ensure execution success and verify exception handling when the binary path is not found.

---
*PR created automatically by Jules for task [16341436446644358102](https://jules.google.com/task/16341436446644358102) started by @insign*