### PR TITLE
feat: Adicionar métodos run e runSync para execução de comandos

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +37,64 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Asynchronously runs the executable with the given [arguments].
+  ///
+  /// Throws a [ProcessException] if the executable cannot be found.
+  Future<ProcessResult> run(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    bool ignoreCache = false,
+  }) async {
+    final executable = await find(ignoreCache: ignoreCache);
+    if (executable == null) {
+      throw ProcessException(
+        cmd,
+        arguments,
+        'Executable not found on system path',
+        2,
+      );
+    }
+    return Process.run(
+      executable,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+    );
+  }
+
+  /// Synchronously runs the executable with the given [arguments].
+  ///
+  /// Throws a [ProcessException] if the executable cannot be found.
+  ProcessResult runSync(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    bool ignoreCache = false,
+  }) {
+    final executable = findSync(ignoreCache: ignoreCache);
+    if (executable == null) {
+      throw ProcessException(
+        cmd,
+        arguments,
+        'Executable not found on system path',
+        2,
+      );
+    }
+    return Process.runSync(
+      executable,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+    );
+  }
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:test/test.dart';
 import 'package:executable/executable.dart';
 
@@ -12,5 +14,30 @@ void main() {
     final ls = Executable('ls');
     final result = await ls.find();
     expect(result, isNotNull);
+  });
+
+  test('Test run method with valid command', () async {
+    final dart = Executable('dart');
+    final result = await dart.run(['--version']);
+    expect(result.exitCode, 0);
+  });
+
+  test('Test runSync method with valid command', () {
+    final dart = Executable('dart');
+    final result = dart.runSync(['--version']);
+    expect(result.exitCode, 0);
+  });
+
+  test(
+    'Test run method with invalid command throws ProcessException',
+    () async {
+      final cmd = Executable('this_command_does_not_exist_xyz');
+      expect(() async => await cmd.run([]), throwsA(isA<ProcessException>()));
+    },
+  );
+
+  test('Test runSync method with invalid command throws ProcessException', () {
+    final cmd = Executable('this_command_does_not_exist_xyz');
+    expect(() => cmd.runSync([]), throwsA(isA<ProcessException>()));
   });
 }


### PR DESCRIPTION
**Resumo das alterações:**
1. Adição dos métodos `run` e `runSync` para a classe `Executable` permitindo assim rodar comandos já integrando as flags passadas e com validação contra comando inexistente.
2. Atualização dos testes contendo cenários de erro e sucesso, executando testes nos dois novos métodos através do comando `dart`.
3. Análise e validação dos padrões do Dart.

---
*PR created automatically by Jules for task [15380281031599076152](https://jules.google.com/task/15380281031599076152) started by @insign*