### PR TITLE
Add execute capability to Executable class

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +37,50 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Asynchronously runs the executable.
+  Future<ProcessResult> run(
+    List<String> args, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    bool ignoreCache = false,
+  }) async {
+    final executablePath = await find(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(cmd, args, 'Executable not found in path.', 2);
+    }
+    return Process.run(
+      executablePath,
+      args,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+    );
+  }
+
+  /// Synchronously runs the executable.
+  ProcessResult runSync(
+    List<String> args, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    bool ignoreCache = false,
+  }) {
+    final executablePath = findSync(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(cmd, args, 'Executable not found in path.', 2);
+    }
+    return Process.runSync(
+      executablePath,
+      args,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+    );
+  }
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -13,4 +13,29 @@ void main() {
     final result = await ls.find();
     expect(result, isNotNull);
   });
+
+  test('Test run method executes successfully', () async {
+    final dartExec = Executable('dart');
+    final result = await dartExec.run(['--version']);
+    expect(result.exitCode, 0);
+  });
+
+  test('Test runSync method executes successfully', () {
+    final dartExec = Executable('dart');
+    final result = dartExec.runSync(['--version']);
+    expect(result.exitCode, 0);
+  });
+
+  test('Test run throws ProcessException when not found', () async {
+    final missingExec = Executable('this_should_not_exist_xyz123');
+    expect(
+      () => missingExec.run([]),
+      throwsA(isA<Exception>()), // In dart process exception
+    );
+  });
+
+  test('Test runSync throws ProcessException when not found', () {
+    final missingExec = Executable('this_should_not_exist_xyz123');
+    expect(() => missingExec.runSync([]), throwsA(isA<Exception>()));
+  });
 }


### PR DESCRIPTION
This pull request introduces `run` and `runSync` execution methods to the `Executable` class. These methods resolve the executable path using the existing `.find()` / `.findSync()` behavior, and if found, execute the binary passing arguments via `dart:io` `Process.run` and `Process.runSync` respectively. If the executable cannot be located, a standard `ProcessException` is thrown. Unit tests have been added to verify successful execution (`dart --version`) and the failure conditions.

---
*PR created automatically by Jules for task [1289780364101737859](https://jules.google.com/task/1289780364101737859) started by @insign*