### PR TITLE
Adicionar a capacidade de execução direta na classe Executable

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +38,70 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Asynchronously runs the executable.
+  /// Throws a [ProcessException] if the executable path cannot be resolved.
+  Future<ProcessResult> run(
+    List<String> args, {
+    bool ignoreCache = false,
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+  }) async {
+    final executablePath = await find(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(
+        cmd,
+        args,
+        'Executable not found in system PATH',
+        2,
+      );
+    }
+    return Process.run(
+      executablePath,
+      args,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
+
+  /// Synchronously runs the executable.
+  /// Throws a [ProcessException] if the executable path cannot be resolved.
+  ProcessResult runSync(
+    List<String> args, {
+    bool ignoreCache = false,
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+  }) {
+    final executablePath = findSync(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(
+        cmd,
+        args,
+        'Executable not found in system PATH',
+        2,
+      );
+    }
+    return Process.runSync(
+      executablePath,
+      args,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:test/test.dart';
 import 'package:executable/executable.dart';
 
@@ -12,5 +13,27 @@ void main() {
     final ls = Executable('ls');
     final result = await ls.find();
     expect(result, isNotNull);
+  });
+
+  test('Test run method executes command', () async {
+    final echo = Executable('echo');
+    final result = await echo.run(['hello']);
+    expect(result.stdout.toString().trim(), 'hello');
+  });
+
+  test('Test runSync method executes command', () {
+    final echo = Executable('echo');
+    final result = echo.runSync(['world']);
+    expect(result.stdout.toString().trim(), 'world');
+  });
+
+  test('Test run throws ProcessException for missing executable', () async {
+    final missing = Executable('missing_executable_12345');
+    expect(() => missing.run(['test']), throwsA(isA<ProcessException>()));
+  });
+
+  test('Test runSync throws ProcessException for missing executable', () {
+    final missing = Executable('missing_executable_12345');
+    expect(() => missing.runSync(['test']), throwsA(isA<ProcessException>()));
   });
 }


### PR DESCRIPTION
A melhoria escolhida para o sistema foi a adição da capacidade de executar os comandos encontrados diretamente pela própria classe `Executable`.

## O que foi feito:
1. **Adição dos métodos `run` e `runSync` em `lib/src/executable_base.dart`**: Eles resolvem o caminho do executável usando os métodos já existentes e, se encontrados, usam o `Process.run` (ou `Process.runSync`) nativo do Dart para executar a ação com parâmetros completos (ex: `workingDirectory`, `environment`, etc.).
2. **Tratamento de Exceções**: Se o executável não for resolvido na verificação, os métodos garantem o lançamento de uma `ProcessException` com os detalhes adequados, ajudando no debug do desenvolvedor.
3. **Novos testes**: Foram implementados testes na suite `test/executable_test.dart` verificando se as execuções do comando `echo` funcionam bem de forma assíncrona e síncrona. Adicionalmente, também há testes validando o lançamento correto do `ProcessException` caso se tente executar um comando inexistente.
4. **Validações e padronização**: O código foi completamente formatado através do `dart format .` e não apresenta nenhum aviso segundo o `dart analyze`. O pre-commit também aprovou toda a implementação.

---
*PR created automatically by Jules for task [14372181548607852930](https://jules.google.com/task/14372181548607852930) started by @insign*