### PR TITLE
feat: add run and runSync methods to Executable

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +37,50 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Asynchronously runs the executable with the given [arguments].
+  Future<ProcessResult> run(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    bool ignoreCache = false,
+  }) async {
+    final executablePath = await find(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(cmd, arguments, 'Executable not found.');
+    }
+    return Process.run(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+    );
+  }
+
+  /// Synchronously runs the executable with the given [arguments].
+  ProcessResult runSync(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    bool ignoreCache = false,
+  }) {
+    final executablePath = findSync(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(cmd, arguments, 'Executable not found.');
+    }
+    return Process.runSync(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+    );
+  }
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -13,4 +13,28 @@ void main() {
     final result = await ls.find();
     expect(result, isNotNull);
   });
+
+  test('Test executable run', () async {
+    final echo = Executable('echo');
+    final result = await echo.run(['hello']);
+    expect(result.exitCode, 0);
+    expect(result.stdout.toString().trim(), 'hello');
+  });
+
+  test('Test executable runSync', () {
+    final echo = Executable('echo');
+    final result = echo.runSync(['hello']);
+    expect(result.exitCode, 0);
+    expect(result.stdout.toString().trim(), 'hello');
+  });
+
+  test('Test executable run exception', () async {
+    final none = Executable('non_existent_executable_123');
+    expect(() => none.run(['test']), throwsA(isA<Exception>()));
+  });
+
+  test('Test executable runSync exception', () {
+    final none = Executable('non_existent_executable_123');
+    expect(() => none.runSync(['test']), throwsA(isA<Exception>()));
+  });
 }


### PR DESCRIPTION
Adicionados os métodos `run` e `runSync` em `lib/src/executable_base.dart` que aproveitam as funções de busca do executável existentes no pacote para permitirem sua fácil execução pelo `dart:io`. Também foram inseridos os devidos testes unitários em `test/executable_test.dart` verificando comportamentos de sucesso e as excessões quando não encontrado.

---
*PR created automatically by Jules for task [16147555479869526557](https://jules.google.com/task/16147555479869526557) started by @insign*