### PR TITLE
feat: adicionar métodos `run` e `runSync` à classe `Executable`

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +38,62 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Asynchronously runs the executable with the given [arguments].
+  ///
+  /// Throws a [ProcessException] if the executable path cannot be resolved.
+  Future<ProcessResult> run(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+  }) async {
+    final path = await find();
+    if (path == null) {
+      throw ProcessException(
+          cmd, arguments, 'Executable path could not be resolved.');
+    }
+    return Process.run(
+      path,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
+
+  /// Synchronously runs the executable with the given [arguments].
+  ///
+  /// Throws a [ProcessException] if the executable path cannot be resolved.
+  ProcessResult runSync(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+  }) {
+    final path = findSync();
+    if (path == null) {
+      throw ProcessException(
+          cmd, arguments, 'Executable path could not be resolved.');
+    }
+    return Process.runSync(
+      path,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:test/test.dart';
 import 'package:executable/executable.dart';
 
@@ -12,5 +14,27 @@ void main() {
     final ls = Executable('ls');
     final result = await ls.find();
     expect(result, isNotNull);
+  });
+
+  test('Test run method executes successfully', () async {
+    final dart = Executable('dart');
+    final result = await dart.run(['--version']);
+    expect(result.exitCode, 0);
+  });
+
+  test('Test run method throws ProcessException on failure', () async {
+    final missing = Executable('non_existent_command_12345');
+    expect(() => missing.run([]), throwsA(isA<ProcessException>()));
+  });
+
+  test('Test runSync method executes successfully', () {
+    final dart = Executable('dart');
+    final result = dart.runSync(['--version']);
+    expect(result.exitCode, 0);
+  });
+
+  test('Test runSync method throws ProcessException on failure', () {
+    final missing = Executable('non_existent_command_12345');
+    expect(() => missing.runSync([]), throwsA(isA<ProcessException>()));
   });
 }


### PR DESCRIPTION
Esta Pull Request adiciona a capacidade da classe `Executable` de, além de localizar comandos no sistema, executá-los utilizando `Process.run` e `Process.runSync` do `dart:io`.

Foram adicionados:
- `Future<ProcessResult> run(...)`
- `ProcessResult runSync(...)`

Adicionalmente, os métodos tratam e lançam uma `ProcessException` caso o executável não seja encontrado (path nulo). Testes unitários foram adicionados em `test/executable_test.dart` garantindo o correto funcionamento com executáveis disponíveis (ex: `dart --version`) e testes de falha para comandos inválidos.

---
*PR created automatically by Jules for task [17505548288536108537](https://jules.google.com/task/17505548288536108537) started by @insign*