### PR TITLE
feat: adicionar métodos run e runSync para execução direta

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +38,62 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Asynchronously runs the executable with the given [arguments].
+  ///
+  /// Throws a [ProcessException] if the executable is not found.
+  Future<ProcessResult> run(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+    bool ignoreCache = false,
+  }) async {
+    final executablePath = await find(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(cmd, arguments, 'Executable not found', 2);
+    }
+    return Process.run(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
+
+  /// Synchronously runs the executable with the given [arguments].
+  ///
+  /// Throws a [ProcessException] if the executable is not found.
+  ProcessResult runSync(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+    bool ignoreCache = false,
+  }) {
+    final executablePath = findSync(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(cmd, arguments, 'Executable not found', 2);
+    }
+    return Process.runSync(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:test/test.dart';
 import 'package:executable/executable.dart';
 
@@ -12,5 +14,27 @@ void main() {
     final ls = Executable('ls');
     final result = await ls.find();
     expect(result, isNotNull);
+  });
+
+  test('Test executable run', () async {
+    final dart = Executable('dart');
+    final result = await dart.run(['--version']);
+    expect(result.exitCode, 0);
+  });
+
+  test('Test executable runSync', () {
+    final dart = Executable('dart');
+    final result = dart.runSync(['--version']);
+    expect(result.exitCode, 0);
+  });
+
+  test('Test executable run throws if not found', () async {
+    final unknown = Executable('some_unknown_command_12345');
+    expect(() => unknown.run([]), throwsA(isA<ProcessException>()));
+  });
+
+  test('Test executable runSync throws if not found', () {
+    final unknown = Executable('some_unknown_command_12345');
+    expect(() => unknown.runSync([]), throwsA(isA<ProcessException>()));
   });
 }


### PR DESCRIPTION
Esta PR introduz a capacidade de executar diretamente um `Executable` uma vez que ele tenha sido instanciado. A classe agora conta com os métodos `run` e `runSync` que repassam os argumentos e opções nativos do `Process.run`/`Process.runSync` em Dart.

Se o comando não existir ou não for encontrado no PATH, os métodos lançam uma `ProcessException`.

- `lib/src/executable_base.dart`: métodos adicionados.
- `test/executable_test.dart`: testes atualizados com casos de sucesso e de exceção.

---
*PR created automatically by Jules for task [17293849638395895736](https://jules.google.com/task/17293849638395895736) started by @insign*