### PR TITLE
Add run and runSync execution methods to Executable

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +38,74 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Asynchronously runs the executable with the given [arguments].
+  ///
+  /// Returns a [ProcessResult] if the executable is found and executed.
+  /// Throws a [ProcessException] if the executable cannot be found.
+  Future<ProcessResult> run(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+    bool ignoreCache = false,
+  }) async {
+    final executablePath = await find(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(
+        cmd,
+        arguments,
+        'Executable "$cmd" not found in PATH.',
+        2,
+      );
+    }
+    return Process.run(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
+
+  /// Synchronously runs the executable with the given [arguments].
+  ///
+  /// Returns a [ProcessResult] if the executable is found and executed.
+  /// Throws a [ProcessException] if the executable cannot be found.
+  ProcessResult runSync(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+    bool ignoreCache = false,
+  }) {
+    final executablePath = findSync(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(
+        cmd,
+        arguments,
+        'Executable "$cmd" not found in PATH.',
+        2,
+      );
+    }
+    return Process.runSync(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:test/test.dart';
 import 'package:executable/executable.dart';
 
@@ -13,4 +15,33 @@ void main() {
     final result = await ls.find();
     expect(result, isNotNull);
   });
+
+  test('Test executable run', () async {
+    // dart is cross-platform and available in path for dart tests
+    final dart = Executable('dart');
+    final result = await dart.run(['--version']);
+    expect(result.exitCode, 0);
+  });
+
+  test('Test executable runSync', () {
+    final dart = Executable('dart');
+    final result = dart.runSync(['--version']);
+    expect(result.exitCode, 0);
+  });
+
+  test(
+    'Test executable run throws ProcessException for non-existent command',
+    () async {
+      final nonExistent = Executable('this_cmd_does_not_exist_123');
+      expect(() => nonExistent.run([]), throwsA(isA<ProcessException>()));
+    },
+  );
+
+  test(
+    'Test executable runSync throws ProcessException for non-existent command',
+    () {
+      final nonExistent = Executable('this_cmd_does_not_exist_123');
+      expect(() => nonExistent.runSync([]), throwsA(isA<ProcessException>()));
+    },
+  );
 }


### PR DESCRIPTION
This introduces `run` and `runSync` to the `Executable` class, allowing users to not just find/check for commands but also execute them directly through the class. Tests are included.

---
*PR created automatically by Jules for task [2209830513671861230](https://jules.google.com/task/2209830513671861230) started by @insign*