### PR TITLE
Adiciona execução direta no `Executable` (`run` e `runSync`)

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +37,64 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Asynchronously runs the executable with the given [arguments].
+  ///
+  /// Throws a [ProcessException] if the executable is not found.
+  Future<ProcessResult> run(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    bool ignoreCache = false,
+  }) async {
+    final executablePath = await find(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(
+        cmd,
+        arguments,
+        'Executable $cmd not found on the system.',
+        2,
+      );
+    }
+    return Process.run(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+    );
+  }
+
+  /// Synchronously runs the executable with the given [arguments].
+  ///
+  /// Throws a [ProcessException] if the executable is not found.
+  ProcessResult runSync(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    bool ignoreCache = false,
+  }) {
+    final executablePath = findSync(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(
+        cmd,
+        arguments,
+        'Executable $cmd not found on the system.',
+        2,
+      );
+    }
+    return Process.runSync(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+    );
+  }
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:test/test.dart';
 import 'package:executable/executable.dart';
 
@@ -12,5 +13,27 @@ void main() {
     final ls = Executable('ls');
     final result = await ls.find();
     expect(result, isNotNull);
+  });
+
+  test('Test executable run success', () async {
+    final dart = Executable('dart');
+    final result = await dart.run(['--version']);
+    expect(result.exitCode, 0);
+  });
+
+  test('Test executable run throws ProcessException', () async {
+    final nonexistent = Executable('nonexistent_cmd_xyz');
+    expect(() => nonexistent.run([]), throwsA(isA<ProcessException>()));
+  });
+
+  test('Test executable runSync success', () {
+    final dart = Executable('dart');
+    final result = dart.runSync(['--version']);
+    expect(result.exitCode, 0);
+  });
+
+  test('Test executable runSync throws ProcessException', () {
+    final nonexistent = Executable('nonexistent_cmd_xyz');
+    expect(() => nonexistent.runSync([]), throwsA(isA<ProcessException>()));
   });
 }


### PR DESCRIPTION
- Adiciona os métodos `run` e `runSync` em `lib/src/executable_base.dart`.
- Modifica os testes (`test/executable_test.dart`) incluindo validação de sucesso e erro esperado para executáveis inexistentes.
- Garante conformidade de formatação e análise sintática em todo o projeto.

---
*PR created automatically by Jules for task [74143662450774204](https://jules.google.com/task/74143662450774204) started by @insign*