### PR TITLE
feat: adiciona métodos run e runSync à classe Executable

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +38,66 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Asynchronously runs the executable with the given [arguments].
+  ///
+  /// Throws a [ProcessException] if the executable cannot be found.
+  /// Additional arguments like [workingDirectory], [environment], etc.,
+  /// are passed to [Process.run].
+  Future<ProcessResult> run(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+    bool ignoreCache = false,
+  }) async {
+    final executablePath = await find(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(cmd, arguments, 'Executable not found.');
+    }
+    return Process.run(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
+
+  /// Synchronously runs the executable with the given [arguments].
+  ///
+  /// Throws a [ProcessException] if the executable cannot be found.
+  /// Additional arguments like [workingDirectory], [environment], etc.,
+  /// are passed to [Process.runSync].
+  ProcessResult runSync(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+    bool ignoreCache = false,
+  }) {
+    final executablePath = findSync(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(cmd, arguments, 'Executable not found.');
+    }
+    return Process.runSync(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:test/test.dart';
 import 'package:executable/executable.dart';
 
@@ -12,5 +14,35 @@ void main() {
     final ls = Executable('ls');
     final result = await ls.find();
     expect(result, isNotNull);
+  });
+
+  test('Test executable run', () async {
+    final echo = Executable('echo');
+    final result = await echo.run(['hello']);
+    expect(result.exitCode, 0);
+    expect(result.stdout.toString().trim(), 'hello');
+  });
+
+  test('Test executable runSync', () {
+    final echo = Executable('echo');
+    final result = echo.runSync(['hello']);
+    expect(result.exitCode, 0);
+    expect(result.stdout.toString().trim(), 'hello');
+  });
+
+  test('Test non-existent executable run', () async {
+    final nonExistent = Executable('this_executable_does_not_exist');
+    expect(
+      () async => await nonExistent.run(['hello']),
+      throwsA(isA<ProcessException>()),
+    );
+  });
+
+  test('Test non-existent executable runSync', () {
+    final nonExistent = Executable('this_executable_does_not_exist');
+    expect(
+      () => nonExistent.runSync(['hello']),
+      throwsA(isA<ProcessException>()),
+    );
   });
 }


### PR DESCRIPTION
A biblioteca `executable` antes apenas permitia buscar o caminho do binário. Com essa alteração, foi adicionada a conveniência de executá-lo diretamente pela classe `Executable` através dos métodos `run` (assíncrono) e `runSync` (síncrono), passando os argumentos e delegando o processo para a API nativa `dart:io`.

Testes atualizados para cobrir a execução bem-sucedida e também a falha quando o executável não existe (exceção `ProcessException` apropriadamente lançada).

---
*PR created automatically by Jules for task [11789964589416427421](https://jules.google.com/task/11789964589416427421) started by @insign*