### PR TITLE
feat: add run and runSync methods to Executable

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +38,56 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Asynchronously runs the executable.
+  Future<ProcessResult> run(
+    List<String> args, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+  }) async {
+    final executablePath = await find();
+    if (executablePath == null) {
+      throw ProcessException(cmd, args, 'Executable not found.');
+    }
+    return Process.run(
+      executablePath,
+      args,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
+
+  /// Synchronously runs the executable.
+  ProcessResult runSync(
+    List<String> args, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+  }) {
+    final executablePath = findSync();
+    if (executablePath == null) {
+      throw ProcessException(cmd, args, 'Executable not found.');
+    }
+    return Process.runSync(
+      executablePath,
+      args,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -1,5 +1,6 @@
 import 'package:test/test.dart';
 import 'package:executable/executable.dart';
+import 'dart:io';
 
 void main() {
   test('Test executable existence', () async {
@@ -12,5 +13,27 @@ void main() {
     final ls = Executable('ls');
     final result = await ls.find();
     expect(result, isNotNull);
+  });
+
+  test('Test executable run', () async {
+    final echo = Executable('echo');
+    final result = await echo.run(['hello']);
+    expect(result.stdout.toString().trim(), 'hello');
+  });
+
+  test('Test executable runSync', () {
+    final echo = Executable('echo');
+    final result = echo.runSync(['hello']);
+    expect(result.stdout.toString().trim(), 'hello');
+  });
+
+  test('Test missing executable run', () async {
+    final missing = Executable('missing_executable_123');
+    expect(() => missing.run([]), throwsA(isA<ProcessException>()));
+  });
+
+  test('Test missing executable runSync', () {
+    final missing = Executable('missing_executable_123');
+    expect(() => missing.runSync([]), throwsA(isA<ProcessException>()));
   });
 }


### PR DESCRIPTION
Adiciona os métodos `run` e `runSync` na classe `Executable`, facilitando a execução do comando encontrado através do pacote `dart:io` (`Process.run` / `Process.runSync`). Lança `ProcessException` caso o executável não seja encontrado. Adiciona testes correspondentes.

---
*PR created automatically by Jules for task [6218200052459953276](https://jules.google.com/task/6218200052459953276) started by @insign*