### PR TITLE
Adicionar capacidade de execução direta em Executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ void main() {
   if (cp.existsSync()) {
     final path = cp.findSync();
     print('The path to ${cp.cmd} executable is $path.');
+
+    // You can also run the executable directly
+    final result = cp.runSync(['--version']);
+    print('Output: ${result.stdout}');
   } else {
     print('The executable ${cp.cmd} was not found on your system.');
   }

--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+import 'dart:io';
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +37,60 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Asynchronously runs the executable with the given [arguments].
+  ///
+  /// Throws a [ProcessException] if the executable path cannot be resolved.
+  Future<ProcessResult> run(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+  }) async {
+    final executablePath = await find();
+    if (executablePath == null) {
+      throw ProcessException(cmd, arguments, 'Executable not found');
+    }
+    return Process.run(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
+
+  /// Synchronously runs the executable with the given [arguments].
+  ///
+  /// Throws a [ProcessException] if the executable path cannot be resolved.
+  ProcessResult runSync(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+  }) {
+    final executablePath = findSync();
+    if (executablePath == null) {
+      throw ProcessException(cmd, arguments, 'Executable not found');
+    }
+    return Process.runSync(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:test/test.dart';
 import 'package:executable/executable.dart';
 
@@ -12,5 +13,27 @@ void main() {
     final ls = Executable('ls');
     final result = await ls.find();
     expect(result, isNotNull);
+  });
+
+  test('Test executable run async', () async {
+    final echo = Executable('echo');
+    final result = await echo.run(['hello']);
+    expect(result.stdout.toString().trim(), 'hello');
+  });
+
+  test('Test executable run sync', () {
+    final echo = Executable('echo');
+    final result = echo.runSync(['hello']);
+    expect(result.stdout.toString().trim(), 'hello');
+  });
+
+  test('Test executable run exception when not found', () async {
+    final nonExistent = Executable('non_existent_command_12345');
+    expect(() => nonExistent.run([]), throwsA(isA<ProcessException>()));
+  });
+
+  test('Test executable runSync exception when not found', () {
+    final nonExistent = Executable('non_existent_command_12345');
+    expect(() => nonExistent.runSync([]), throwsA(isA<ProcessException>()));
   });
 }


### PR DESCRIPTION
Esta alteração adiciona uma nova e útil funcionalidade à classe `Executable`: a capacidade de não apenas encontrar o executável no PATH, mas também de executá-lo diretamente, passando argumentos.

A melhoria envolveu a adição dos métodos `run` (assíncrono) e `runSync` (síncrono), que replicam a assinatura de `Process.run` do `dart:io`. Se o comando especificado não for encontrado, ele lançará um `ProcessException` apropriado, mantendo a consistência com a API nativa.

Foram adicionados testes em `test/executable_test.dart` para cobrir caminhos de sucesso e de falha, e também um exemplo no `README.md` mostrando a nova funcionalidade. O código foi validado com o analisador estático do Dart (`dart analyze`) e a suíte de testes (`dart test`).

---
*PR created automatically by Jules for task [17046067757832535990](https://jules.google.com/task/17046067757832535990) started by @insign*