### PR TITLE
feat: adicionar métodos de execução (`run` e `runSync`) na classe `Executable`

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +38,58 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Asynchronously runs the executable with the given [args].
+  Future<ProcessResult> run(
+    List<String> args, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+    bool ignoreCache = false,
+  }) async {
+    final executablePath = await find(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(cmd, args, 'Executable not found', 0);
+    }
+    return Process.run(
+      executablePath,
+      args,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
+
+  /// Synchronously runs the executable with the given [args].
+  ProcessResult runSync(
+    List<String> args, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+    bool ignoreCache = false,
+  }) {
+    final executablePath = findSync(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(cmd, args, 'Executable not found', 0);
+    }
+    return Process.runSync(
+      executablePath,
+      args,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -1,5 +1,7 @@
-import 'package:test/test.dart';
+import 'dart:io';
+
 import 'package:executable/executable.dart';
+import 'package:test/test.dart';
 
 void main() {
   test('Test executable existence', () async {
@@ -12,5 +14,27 @@ void main() {
     final ls = Executable('ls');
     final result = await ls.find();
     expect(result, isNotNull);
+  });
+
+  test('Test executable run async', () async {
+    final ls = Executable('ls');
+    final result = await ls.run(['-l']);
+    expect(result.exitCode, 0);
+  });
+
+  test('Test executable run async failure', () async {
+    final inexistent = Executable('inexistent_executable_xyz');
+    expect(() async => await inexistent.run([]), throwsA(isA<ProcessException>()));
+  });
+
+  test('Test executable runSync', () {
+    final ls = Executable('ls');
+    final result = ls.runSync(['-l']);
+    expect(result.exitCode, 0);
+  });
+
+  test('Test executable runSync failure', () {
+    final inexistent = Executable('inexistent_executable_xyz');
+    expect(() => inexistent.runSync([]), throwsA(isA<ProcessException>()));
   });
 }


### PR DESCRIPTION
Esta submissão adiciona os métodos `run` (assíncrono) e `runSync` (síncrono) na classe `Executable`, permitindo que ela não apenas encontre executáveis e verifique sua existência, mas também os execute passando argumentos. Isso melhora a utilidade geral da biblioteca. Testes unitários foram adicionados e todos passam corretamente. Nenhum arquivo temporário foi comitado.

---
*PR created automatically by Jules for task [6835649464517970977](https://jules.google.com/task/6835649464517970977) started by @insign*