### PR TITLE
Adicionar métodos de execução à classe Executable

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +36,50 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Runs the executable [cmd] asynchronously with the given [args].
+  Future<ProcessResult> run(
+    List<String> args, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    bool ignoreCache = false,
+  }) async {
+    final executablePath = await find(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(cmd, args, 'Executable not found.');
+    }
+    return Process.run(
+      executablePath,
+      args,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+    );
+  }
+
+  /// Runs the executable [cmd] synchronously with the given [args].
+  ProcessResult runSync(
+    List<String> args, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    bool ignoreCache = false,
+  }) {
+    final executablePath = findSync(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(cmd, args, 'Executable not found.');
+    }
+    return Process.runSync(
+      executablePath,
+      args,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+    );
+  }
 }

--- a/test/run_test.dart
+++ b/test/run_test.dart
@@ -1,0 +1,27 @@
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:executable/executable.dart';
+
+void main() {
+  test('Test run method', () async {
+    final echo = Executable('echo');
+    final result = await echo.run(['hello']);
+    expect(result.stdout.toString().trim(), 'hello');
+  });
+
+  test('Test runSync method', () {
+    final echo = Executable('echo');
+    final result = echo.runSync(['hello']);
+    expect(result.stdout.toString().trim(), 'hello');
+  });
+
+  test('Test run method with invalid executable', () async {
+    final invalid = Executable('invalid_executable_123');
+    expect(() => invalid.run([]), throwsA(isA<ProcessException>()));
+  });
+
+  test('Test runSync method with invalid executable', () {
+    final invalid = Executable('invalid_executable_123');
+    expect(() => invalid.runSync([]), throwsA(isA<ProcessException>()));
+  });
+}


### PR DESCRIPTION
Implementação de métodos para executar de forma síncrona e assíncrona o binário referenciado pela classe `Executable`. Esta era uma melhoria necessária dado que o pacote anteriormente apenas determinava o caminho no sistema, agora ele também agiliza a execução propriamente dita. Adicionados testes em `test/run_test.dart` para validar casos de sucesso usando o `echo` e tratamento de erros (lançamento do `ProcessException`). Todo o código passou pelo `dart format` e `dart analyze` sem registrar regressões na test suite original.

---
*PR created automatically by Jules for task [12379691508948493581](https://jules.google.com/task/12379691508948493581) started by @insign*