### PR TITLE
feat: add run and runSync execution methods

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +37,54 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Asynchronously runs the executable with the given [arguments].
+  ///
+  /// Throws a [ProcessException] if the executable path cannot be resolved.
+  Future<ProcessResult> run(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    bool ignoreCache = false,
+  }) async {
+    final executablePath = await find(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(cmd, arguments, 'Executable not found.');
+    }
+    return Process.run(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+    );
+  }
+
+  /// Synchronously runs the executable with the given [arguments].
+  ///
+  /// Throws a [ProcessException] if the executable path cannot be resolved.
+  ProcessResult runSync(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    bool ignoreCache = false,
+  }) {
+    final executablePath = findSync(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(cmd, arguments, 'Executable not found.');
+    }
+    return Process.runSync(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+    );
+  }
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:test/test.dart';
 import 'package:executable/executable.dart';
 
@@ -13,4 +15,38 @@ void main() {
     final result = await ls.find();
     expect(result, isNotNull);
   });
+
+  test('Test run method (async)', () async {
+    final dart = Executable('dart');
+    final result = await dart.run(['--version']);
+    expect(result.exitCode, 0);
+  });
+
+  test('Test runSync method (sync)', () {
+    final dart = Executable('dart');
+    final result = dart.runSync(['--version']);
+    expect(result.exitCode, 0);
+  });
+
+  test(
+    'Test run method (async) throws ProcessException for missing executable',
+    () async {
+      final missingCmd = Executable('this_cmd_does_not_exist_123');
+      expect(
+        () async => await missingCmd.run(['--version']),
+        throwsA(isA<ProcessException>()),
+      );
+    },
+  );
+
+  test(
+    'Test runSync method (sync) throws ProcessException for missing executable',
+    () {
+      final missingCmd = Executable('this_cmd_does_not_exist_456');
+      expect(
+        () => missingCmd.runSync(['--version']),
+        throwsA(isA<ProcessException>()),
+      );
+    },
+  );
 }


### PR DESCRIPTION
## What does this PR do?
Adds the ability to directly execute commands using `Executable` via `run` (asynchronous) and `runSync` (synchronous) methods. Previously, `Executable` could only find paths and check for existence; this adds functional parity allowing developers to directly trigger the underlying `Process.run`/`Process.runSync` after automatically resolving the command from the PATH.

## Why is this change needed?
To make the library more cohesive and practical. Users of the library often need to execute the command after finding it. This update abstracts away the boilerplate of manually using `Process.run` and checking if `Executable.find()` returned null.

## How is this tested?
- Added tests asserting `exitCode == 0` when executing `dart --version` using both `run` and `runSync`.
- Added tests asserting a `ProcessException` is thrown when attempting to execute an invalid command (`this_cmd_does_not_exist_...`).
- Tests executed successfully with `dart test`. All formatting (`dart format`) and linting (`dart analyze`) checks pass without issues.

---
*PR created automatically by Jules for task [18075574530006785588](https://jules.google.com/task/18075574530006785588) started by @insign*