### PR TITLE
feat: add execution methods to Executable

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +38,74 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Asynchronously runs the executable with the given [arguments].
+  ///
+  /// Returns a [Future<ProcessResult>] with the result of running the command.
+  /// Throws a [ProcessException] if the executable is not found.
+  Future<ProcessResult> run(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+    bool ignoreCache = false,
+  }) async {
+    final executablePath = await find(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(
+        cmd,
+        arguments,
+        'Executable not found on your system.',
+      );
+    }
+
+    return Process.run(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
+
+  /// Synchronously runs the executable with the given [arguments].
+  ///
+  /// Returns a [ProcessResult] with the result of running the command.
+  /// Throws a [ProcessException] if the executable is not found.
+  ProcessResult runSync(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+    bool ignoreCache = false,
+  }) {
+    final executablePath = findSync(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(
+        cmd,
+        arguments,
+        'Executable not found on your system.',
+      );
+    }
+
+    return Process.runSync(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -1,5 +1,7 @@
-import 'package:test/test.dart';
+import 'dart:io';
+
 import 'package:executable/executable.dart';
+import 'package:test/test.dart';
 
 void main() {
   test('Test executable existence', () async {
@@ -13,4 +15,32 @@ void main() {
     final result = await ls.find();
     expect(result, isNotNull);
   });
+
+  test('Test run method executes command', () async {
+    final dart = Executable('dart');
+    final result = await dart.run(['--version']);
+    expect(result.exitCode, 0);
+  });
+
+  test(
+    'Test run method throws ProcessException if executable not found',
+    () async {
+      final notFound = Executable('non_existent_executable_12345');
+      expect(() => notFound.run([]), throwsA(isA<ProcessException>()));
+    },
+  );
+
+  test('Test runSync method executes command', () {
+    final dart = Executable('dart');
+    final result = dart.runSync(['--version']);
+    expect(result.exitCode, 0);
+  });
+
+  test(
+    'Test runSync method throws ProcessException if executable not found',
+    () {
+      final notFound = Executable('non_existent_executable_12345');
+      expect(() => notFound.runSync([]), throwsA(isA<ProcessException>()));
+    },
+  );
 }


### PR DESCRIPTION
Implementação de uma melhoria adicionando os métodos `run` e `runSync` para a classe `Executable`. Isso permite que o próprio objeto cuide da execução em vez de apenas buscar o caminho, agregando as funcionalidades de `Process.run` e `Process.runSync` do `dart:io`. Também lida com a ausência do executável lançando uma `ProcessException`. Os testes foram adicionados de acordo. Todos os testes passam e o código foi verificado e formatado.

---
*PR created automatically by Jules for task [3690291547530933621](https://jules.google.com/task/3690291547530933621) started by @insign*