### PR TITLE
feat: adicionar métodos de execução na classe Executable

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +36,56 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Asynchronously runs the executable with the given [arguments].
+  ///
+  /// Throws a [ProcessException] if the executable could not be found.
+  Future<ProcessResult> run(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    bool ignoreCache = false,
+  }) async {
+    final executablePath = await find(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(
+          cmd, arguments, 'Executable not found on the system.');
+    }
+    return await Process.run(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+    );
+  }
+
+  /// Synchronously runs the executable with the given [arguments].
+  ///
+  /// Throws a [ProcessException] if the executable could not be found.
+  ProcessResult runSync(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    bool ignoreCache = false,
+  }) {
+    final executablePath = findSync(ignoreCache: ignoreCache);
+    if (executablePath == null) {
+      throw ProcessException(
+          cmd, arguments, 'Executable not found on the system.');
+    }
+    return Process.runSync(
+      executablePath,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+    );
+  }
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:test/test.dart';
 import 'package:executable/executable.dart';
 
@@ -12,5 +13,33 @@ void main() {
     final ls = Executable('ls');
     final result = await ls.find();
     expect(result, isNotNull);
+  });
+
+  test('Test executable run async', () async {
+    final dart = Executable('dart');
+    final result = await dart.run(['--version']);
+    expect(result.exitCode, 0);
+  });
+
+  test('Test executable runSync', () {
+    final dart = Executable('dart');
+    final result = dart.runSync(['--version']);
+    expect(result.exitCode, 0);
+  });
+
+  test('Test executable run throws ProcessException if not found', () async {
+    final fakeExe = Executable('non_existent_executable_12345');
+    expect(
+      () async => await fakeExe.run(['--version']),
+      throwsA(isA<ProcessException>()),
+    );
+  });
+
+  test('Test executable runSync throws ProcessException if not found', () {
+    final fakeExe = Executable('non_existent_executable_12345');
+    expect(
+      () => fakeExe.runSync(['--version']),
+      throwsA(isA<ProcessException>()),
+    );
   });
 }


### PR DESCRIPTION
Foi solicitada a adição de uma melhoria ao projeto. A melhoria escolhida e aplicada foi a adição de métodos de execução (`run` e `runSync`) na própria classe `Executable`. Agora a classe é capaz não apenas de procurar e validar a existência do executável no PATH, mas também de executá-lo diretamente e repassar os argumentos/flags com facilidade, integrando de forma limpa o uso do pacote com o `Process.run` nativo do Dart. Foram incluídos testes cobrindo os casos de sucesso (retornando o código de saída 0) e falha (lançando uma `ProcessException` caso o comando não exista). Tudo foi documentado nos comentários dos métodos, respeitando o padrão existente, sem adição de arquivos temporários.

---
*PR created automatically by Jules for task [5544372729083182538](https://jules.google.com/task/5544372729083182538) started by @insign*