### PR TITLE
Adição de métodos run e runSync ao Executable

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -35,4 +38,60 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({bool ignoreCache = false}) =>
       findSync(ignoreCache: ignoreCache) != null;
+
+  /// Asynchronously runs the executable with the given [arguments].
+  ///
+  /// Throws a [ProcessException] if the executable is not found.
+  Future<ProcessResult> run(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+  }) async {
+    final path = await find();
+    if (path == null) {
+      throw ProcessException(cmd, arguments, 'Executable not found.');
+    }
+    return Process.run(
+      path,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
+
+  /// Synchronously runs the executable with the given [arguments].
+  ///
+  /// Throws a [ProcessException] if the executable is not found.
+  ProcessResult runSync(
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+  }) {
+    final path = findSync();
+    if (path == null) {
+      throw ProcessException(cmd, arguments, 'Executable not found.');
+    }
+    return Process.runSync(
+      path,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    );
+  }
 }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:test/test.dart';
 import 'package:executable/executable.dart';
 
@@ -12,5 +14,35 @@ void main() {
     final ls = Executable('ls');
     final result = await ls.find();
     expect(result, isNotNull);
+  });
+
+  test('Test executable run', () async {
+    final echo = Executable('echo');
+    final result = await echo.run(['hello']);
+    expect(result.exitCode, 0);
+    expect(result.stdout.toString().trim(), 'hello');
+  });
+
+  test('Test executable runSync', () {
+    final echo = Executable('echo');
+    final result = echo.runSync(['hello']);
+    expect(result.exitCode, 0);
+    expect(result.stdout.toString().trim(), 'hello');
+  });
+
+  test('Test executable run exception', () async {
+    final nonexistent = Executable('nonexistent_executable_12345');
+    expect(
+      () async => await nonexistent.run(['test']),
+      throwsA(isA<ProcessException>()),
+    );
+  });
+
+  test('Test executable runSync exception', () {
+    final nonexistent = Executable('nonexistent_executable_12345');
+    expect(
+      () => nonexistent.runSync(['test']),
+      throwsA(isA<ProcessException>()),
+    );
   });
 }


### PR DESCRIPTION
Adiciona os métodos `run` e `runSync` à classe `Executable` do pacote. Os métodos facilitam a execução de binários utilizando as funções equivalentes disponíveis em `dart:io` e repassam as opções necessárias de execução. Lançam `ProcessException` se o comando não for resolvido. Foram incluídos os testes correspondentes em `test/executable_test.dart` bem como rodadas as ferramentas de formatação e verificação.

---
*PR created automatically by Jules for task [15521811698745729932](https://jules.google.com/task/15521811698745729932) started by @insign*