### PR TITLE
feat: suporte a environment customizado na busca de executáveis

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -15,8 +15,14 @@ class Executable {
       cmd.contains('/') || (Platform.isWindows && cmd.contains('\\'));
 
   /// Asynchronously finds the path to the executable [cmd].
-  Future<String?> find({bool ignoreCache = false}) async {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  Future<String?> find({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async {
+    // Se passarmos um environment customizado, ignoramos a leitura/gravação no cache global.
+    final useCache = !ignoreCache && environment == null;
+    if (useCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -25,7 +31,11 @@ class Executable {
       final file = File(cmd);
       if (await file.exists()) {
         if (Platform.isWindows) {
-          if (_isWindowsExecutable(cmd)) {
+          if (_isWindowsExecutable(
+            cmd,
+            environment: environment,
+            includeParentEnvironment: includeParentEnvironment,
+          )) {
             result = file.absolute.path;
           }
         } else if (await _isPosixExecutable(file)) {
@@ -34,18 +44,40 @@ class Executable {
       }
     }
 
-    result ??= await which(cmd);
-    _whichResults[cmd] = result;
+    result ??= await which(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+
+    if (useCache) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Asynchronously checks if the executable [cmd] exists.
-  Future<bool> exists({bool ignoreCache = false}) async =>
-      await find(ignoreCache: ignoreCache) != null;
+  Future<bool> exists({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async =>
+      await find(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) !=
+      null;
 
   /// Synchronously finds the path to the executable [cmd].
-  String? findSync({bool ignoreCache = false}) {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  String? findSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) {
+    // Se passarmos um environment customizado, ignoramos a leitura/gravação no cache global.
+    final useCache = !ignoreCache && environment == null;
+    if (useCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -54,7 +86,11 @@ class Executable {
       final file = File(cmd);
       if (file.existsSync()) {
         if (Platform.isWindows) {
-          if (_isWindowsExecutable(cmd)) {
+          if (_isWindowsExecutable(
+            cmd,
+            environment: environment,
+            includeParentEnvironment: includeParentEnvironment,
+          )) {
             result = file.absolute.path;
           }
         } else if (_isPosixExecutableSync(file)) {
@@ -63,14 +99,30 @@ class Executable {
       }
     }
 
-    result ??= whichSync(cmd);
-    _whichResults[cmd] = result;
+    result ??= whichSync(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+
+    if (useCache) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Synchronously checks if the executable [cmd] exists.
-  bool existsSync({bool ignoreCache = false}) =>
-      findSync(ignoreCache: ignoreCache) != null;
+  bool existsSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) =>
+      findSync(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) !=
+      null;
 
   /// Asynchronously runs the executable with the given [arguments].
   Future<ProcessResult> run(
@@ -82,7 +134,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) async {
-    final path = await find();
+    final path = await find(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }
@@ -109,7 +164,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) {
-    final path = findSync();
+    final path = findSync(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }
@@ -126,8 +184,15 @@ class Executable {
     );
   }
 
-  bool _isWindowsExecutable(String path) {
-    final pathExt = Platform.environment['PATHEXT'] ?? '.EXE;.BAT;.CMD;.COM';
+  bool _isWindowsExecutable(
+    String path, {
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) {
+    final env = includeParentEnvironment
+        ? {...Platform.environment, ...?environment}
+        : (environment ?? <String, String>{});
+    final pathExt = env['PATHEXT'] ?? '.EXE;.BAT;.CMD;.COM';
     final extensions = pathExt.split(';').where((ext) => ext.isNotEmpty);
     final upperPath = path.toUpperCase();
     return extensions.any((ext) => upperPath.endsWith(ext.toUpperCase()));

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -45,4 +45,56 @@ void main() {
       throwsA(isA<ProcessException>()),
     );
   });
+
+  test('Test executable with custom environment', () async {
+    final tempDir = await Directory.systemTemp.createTemp(
+      'executable_env_test_',
+    );
+    addTearDown(() => tempDir.delete(recursive: true));
+
+    var cmdName = 'custom_env_cmd_12345';
+    if (Platform.isWindows) {
+      cmdName += '.bat';
+    }
+
+    final exePath = '${tempDir.path}${Platform.pathSeparator}$cmdName';
+    final file = File(exePath);
+    if (Platform.isWindows) {
+      await file.writeAsString('@echo off\necho custom_env');
+    } else {
+      await file.writeAsString('#!/bin/sh\necho custom_env');
+      await Process.run('chmod', ['+x', exePath]);
+    }
+
+    final cmdArg = 'custom_env_cmd_12345';
+    final customExecutable = Executable(cmdArg);
+
+    // Should not be found without custom environment
+    final notFoundResult = await customExecutable.find();
+    expect(notFoundResult, isNull);
+
+    // Should be found with custom environment (will bypass cache automatically)
+    final separator = Platform.isWindows ? ';' : ':';
+    final envPath = Platform.environment['PATH'] ?? '';
+    final newPath = '${tempDir.path}$separator$envPath';
+
+    final foundResult = await customExecutable.find(
+      environment: {...Platform.environment, 'PATH': newPath},
+    );
+    expect(foundResult, isNotNull);
+
+    // Cache should not be poisoned: find without custom environment should still return null
+    final notFoundResultAfter = await customExecutable.find();
+    expect(notFoundResultAfter, isNull);
+
+    // Sync find test
+    final syncFoundResult = customExecutable.findSync(
+      environment: {...Platform.environment, 'PATH': newPath},
+    );
+    expect(syncFoundResult, isNotNull);
+
+    // Cache should not be poisoned: findSync without custom environment should still return null
+    final syncNotFoundResultAfter = customExecutable.findSync();
+    expect(syncNotFoundResultAfter, isNull);
+  });
 }


### PR DESCRIPTION
Adiciona suporte ao uso de parâmetros `environment` na busca de caminhos de executáveis. Quando um ambiente customizado é fornecido, não utilizamos o cache de busca para evitar cache poisoning. Adicionados testes unitários.

---
*PR created automatically by Jules for task [740350125347790983](https://jules.google.com/task/740350125347790983) started by @insign*