### PR TITLE
Adiciona suporte a variáveis de ambiente customizadas na classe Executable

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -15,8 +15,15 @@ class Executable {
       cmd.contains('/') || (Platform.isWindows && cmd.contains('\\'));
 
   /// Asynchronously finds the path to the executable [cmd].
-  Future<String?> find({bool ignoreCache = false}) async {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  Future<String?> find({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async {
+    // Bypass cache if environment is provided or parent env is excluded to prevent cache poisoning.
+    final useCache = !ignoreCache && environment == null && includeParentEnvironment;
+
+    if (useCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -34,18 +41,39 @@ class Executable {
       }
     }
 
-    result ??= await which(cmd);
-    _whichResults[cmd] = result;
+    result ??= await which(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+    if (useCache) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Asynchronously checks if the executable [cmd] exists.
-  Future<bool> exists({bool ignoreCache = false}) async =>
-      await find(ignoreCache: ignoreCache) != null;
+  Future<bool> exists({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async =>
+      await find(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) != null;
 
   /// Synchronously finds the path to the executable [cmd].
-  String? findSync({bool ignoreCache = false}) {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  String? findSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) {
+    // Bypass cache if environment is provided or parent env is excluded to prevent cache poisoning.
+    final useCache = !ignoreCache && environment == null && includeParentEnvironment;
+
+    if (useCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -63,14 +91,28 @@ class Executable {
       }
     }
 
-    result ??= whichSync(cmd);
-    _whichResults[cmd] = result;
+    result ??= whichSync(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+    if (useCache) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Synchronously checks if the executable [cmd] exists.
-  bool existsSync({bool ignoreCache = false}) =>
-      findSync(ignoreCache: ignoreCache) != null;
+  bool existsSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) =>
+      findSync(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) != null;
 
   /// Asynchronously runs the executable with the given [arguments].
   Future<ProcessResult> run(
@@ -82,7 +124,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) async {
-    final path = await find();
+    final path = await find(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }
@@ -109,7 +154,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) {
-    final path = findSync();
+    final path = findSync(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -45,4 +45,57 @@ void main() {
       throwsA(isA<ProcessException>()),
     );
   });
+
+  test('Test executable with custom environment bypasses cache correctly', () async {
+    // We use a dummy executable name
+    final dummyName = 'dummy_env_executable_123';
+    final dummy = Executable(dummyName);
+
+    // Initial check - should not exist
+    expect(await dummy.exists(), false);
+    expect(dummy.existsSync(), false);
+
+    // Create a temporary directory with a dummy executable
+    final tempDir = await Directory.systemTemp.createTemp('executable_env_test_');
+    addTearDown(() => tempDir.delete(recursive: true));
+
+    var cmdName = dummyName;
+    if (Platform.isWindows) {
+      cmdName += '.bat';
+    }
+
+    final exePath = '${tempDir.path}${Platform.pathSeparator}$cmdName';
+    final file = File(exePath);
+    if (Platform.isWindows) {
+      await file.writeAsString('@echo off\necho dummy');
+    } else {
+      await file.writeAsString('#!/bin/sh\necho dummy');
+      await Process.run('chmod', ['+x', exePath]);
+    }
+
+    // Still should not be found in default environment due to negative caching or just missing from PATH
+    expect(await dummy.exists(), false);
+    expect(dummy.existsSync(), false);
+
+    final separator = Platform.isWindows ? ';' : ':';
+    final envPath = Platform.environment['PATH'] ?? '';
+    final newPath = '${tempDir.path}$separator$envPath';
+    final customEnv = {...Platform.environment, 'PATH': newPath};
+
+    // With custom environment, it should be found
+    final findResult = await dummy.find(environment: customEnv);
+    expect(findResult, isNotNull);
+    expect(File(findResult!).existsSync(), true);
+
+    final findSyncResult = dummy.findSync(environment: customEnv);
+    expect(findSyncResult, isNotNull);
+    expect(File(findSyncResult!).existsSync(), true);
+
+    expect(await dummy.exists(environment: customEnv), true);
+    expect(dummy.existsSync(environment: customEnv), true);
+
+    // Ensure cache wasn't poisoned
+    expect(await dummy.exists(), false);
+    expect(dummy.existsSync(), false);
+  });
 }


### PR DESCRIPTION
Adiciona suporte a variáveis de ambiente customizadas na classe Executable. Isso resolve um problema onde o executável era resolvido usando o ambiente padrão antes do comando `Process.run`, mesmo quando as variáveis de ambiente personalizadas (`environment`) eram fornecidas para uso interno. O cache também foi atualizado para evitar corrompimento e testes adicionais foram incluídos para validar o cenário. Nenhum arquivo temporário foi adicionado.

---
*PR created automatically by Jules for task [350661711630843333](https://jules.google.com/task/350661711630843333) started by @insign*