### PR TITLE
Feat: Adiciona suporte a variaveis de ambiente customizadas na resolucao de executaveis

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -15,8 +15,13 @@ class Executable {
       cmd.contains('/') || (Platform.isWindows && cmd.contains('\\'));
 
   /// Asynchronously finds the path to the executable [cmd].
-  Future<String?> find({bool ignoreCache = false}) async {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  Future<String?> find({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async {
+    final useCache = environment == null && includeParentEnvironment;
+    if (!ignoreCache && useCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -25,7 +30,11 @@ class Executable {
       final file = File(cmd);
       if (await file.exists()) {
         if (Platform.isWindows) {
-          if (_isWindowsExecutable(cmd)) {
+          if (_isWindowsExecutable(
+            cmd,
+            environment: environment,
+            includeParentEnvironment: includeParentEnvironment,
+          )) {
             result = file.absolute.path;
           }
         } else if (await _isPosixExecutable(file)) {
@@ -34,18 +43,39 @@ class Executable {
       }
     }
 
-    result ??= await which(cmd);
-    _whichResults[cmd] = result;
+    result ??= await which(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+
+    if (useCache) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Asynchronously checks if the executable [cmd] exists.
-  Future<bool> exists({bool ignoreCache = false}) async =>
-      await find(ignoreCache: ignoreCache) != null;
+  Future<bool> exists({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async =>
+      await find(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) !=
+      null;
 
   /// Synchronously finds the path to the executable [cmd].
-  String? findSync({bool ignoreCache = false}) {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  String? findSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) {
+    final useCache = environment == null && includeParentEnvironment;
+    if (!ignoreCache && useCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -54,7 +84,11 @@ class Executable {
       final file = File(cmd);
       if (file.existsSync()) {
         if (Platform.isWindows) {
-          if (_isWindowsExecutable(cmd)) {
+          if (_isWindowsExecutable(
+            cmd,
+            environment: environment,
+            includeParentEnvironment: includeParentEnvironment,
+          )) {
             result = file.absolute.path;
           }
         } else if (_isPosixExecutableSync(file)) {
@@ -63,14 +97,30 @@ class Executable {
       }
     }
 
-    result ??= whichSync(cmd);
-    _whichResults[cmd] = result;
+    result ??= whichSync(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+
+    if (useCache) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Synchronously checks if the executable [cmd] exists.
-  bool existsSync({bool ignoreCache = false}) =>
-      findSync(ignoreCache: ignoreCache) != null;
+  bool existsSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) =>
+      findSync(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) !=
+      null;
 
   /// Asynchronously runs the executable with the given [arguments].
   Future<ProcessResult> run(
@@ -82,7 +132,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) async {
-    final path = await find();
+    final path = await find(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }
@@ -109,7 +162,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) {
-    final path = findSync();
+    final path = findSync(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }
@@ -126,8 +182,21 @@ class Executable {
     );
   }
 
-  bool _isWindowsExecutable(String path) {
-    final pathExt = Platform.environment['PATHEXT'] ?? '.EXE;.BAT;.CMD;.COM';
+  bool _isWindowsExecutable(
+    String path, {
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) {
+    String? pathExt;
+    if (environment != null) {
+      pathExt = environment['PATHEXT'];
+    }
+
+    if (includeParentEnvironment && pathExt == null) {
+      pathExt = Platform.environment['PATHEXT'];
+    }
+
+    pathExt ??= '.EXE;.BAT;.CMD;.COM';
     final extensions = pathExt.split(';').where((ext) => ext.isNotEmpty);
     final upperPath = path.toUpperCase();
     return extensions.any((ext) => upperPath.endsWith(ext.toUpperCase()));

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -45,4 +45,58 @@ void main() {
       throwsA(isA<ProcessException>()),
     );
   });
+
+  test('Test executable environment variables in find', () async {
+    final tempDir = Directory.systemTemp.createTempSync('executable_test_');
+    try {
+      final dummyExecutableName =
+          'dummy_executable_test_${DateTime.now().millisecondsSinceEpoch}${Platform.isWindows ? '.bat' : ''}';
+      final dummyExecutablePath = '${tempDir.path}/$dummyExecutableName';
+      final dummyExecutable = File(dummyExecutablePath);
+
+      if (Platform.isWindows) {
+        dummyExecutable.writeAsStringSync('@echo off\necho hello');
+      } else {
+        dummyExecutable.writeAsStringSync('#!/bin/sh\necho hello');
+        Process.runSync('chmod', ['+x', dummyExecutablePath]);
+      }
+
+      final exec = Executable(dummyExecutableName);
+
+      // Deve falhar, não está no PATH global
+      final resultGlobal = await exec.find();
+      expect(resultGlobal, isNull);
+
+      // Deve achar, pois passamos o ambiente correto
+      final env = {'PATH': tempDir.path};
+      final resultEnv = await exec.find(
+        environment: env,
+        includeParentEnvironment: false,
+      );
+      expect(resultEnv, isNotNull);
+
+      final resultEnvSync = exec.findSync(
+        environment: env,
+        includeParentEnvironment: false,
+      );
+      expect(resultEnvSync, isNotNull);
+
+      // Testar execução
+      final runResult = await exec.run(
+        [],
+        environment: env,
+        includeParentEnvironment: false,
+      );
+      expect(runResult.exitCode, 0);
+
+      final runSyncResult = exec.runSync(
+        [],
+        environment: env,
+        includeParentEnvironment: false,
+      );
+      expect(runSyncResult.exitCode, 0);
+    } finally {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
 }


### PR DESCRIPTION
Adiciona a possibilidade de passar `environment` customizado e `includeParentEnvironment`
aos metodos `find`, `findSync`, `exists`, `existsSync`, `run` e `runSync` da classe `Executable`.

- Evita a utilizacao indevida do cache (`cache poisoning`) quando o PATH ou o ambiente e
  alterado por parametros, garantindo determinismo na execucao paralela.
- Atualiza a resolucao do `_isWindowsExecutable` baseada na variavel `PATHEXT` correta
  no ambiente injetado.
- Inclui teste cobrindo a funcionalidade sem contaminar cache ou alterar arquivos temporarios
  da base de dados (testes ajustados e arquivos de .diff/.orig descartados).

---
*PR created automatically by Jules for task [15804141628668128743](https://jules.google.com/task/15804141628668128743) started by @insign*