### PR TITLE
feat: suportar custom environment na resolução do path de executáveis

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -15,8 +15,13 @@ class Executable {
       cmd.contains('/') || (Platform.isWindows && cmd.contains('\\'));
 
   /// Asynchronously finds the path to the executable [cmd].
-  Future<String?> find({bool ignoreCache = false}) async {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  Future<String?> find({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async {
+    final useCache = !ignoreCache && environment == null && includeParentEnvironment;
+    if (useCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -34,18 +39,38 @@ class Executable {
       }
     }
 
-    result ??= await which(cmd);
-    _whichResults[cmd] = result;
+    result ??= await which(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+
+    if (useCache) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Asynchronously checks if the executable [cmd] exists.
-  Future<bool> exists({bool ignoreCache = false}) async =>
-      await find(ignoreCache: ignoreCache) != null;
+  Future<bool> exists({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async =>
+      await find(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) != null;
 
   /// Synchronously finds the path to the executable [cmd].
-  String? findSync({bool ignoreCache = false}) {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  String? findSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) {
+    final useCache = !ignoreCache && environment == null && includeParentEnvironment;
+    if (useCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -63,14 +88,29 @@ class Executable {
       }
     }
 
-    result ??= whichSync(cmd);
-    _whichResults[cmd] = result;
+    result ??= whichSync(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+
+    if (useCache) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Synchronously checks if the executable [cmd] exists.
-  bool existsSync({bool ignoreCache = false}) =>
-      findSync(ignoreCache: ignoreCache) != null;
+  bool existsSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) =>
+      findSync(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) != null;
 
   /// Asynchronously runs the executable with the given [arguments].
   Future<ProcessResult> run(
@@ -82,7 +122,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) async {
-    final path = await find();
+    final path = await find(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }
@@ -109,7 +152,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) {
-    final path = findSync();
+    final path = findSync(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }

--- a/test/executable_environment_test.dart
+++ b/test/executable_environment_test.dart
@@ -1,0 +1,96 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:executable/executable.dart';
+
+void main() {
+  group('Executable custom environment', () {
+    late Directory tempDir;
+    late String testExeName;
+    late String testExePath;
+    late Map<String, String> customEnv;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('executable_test_');
+      testExeName = Platform.isWindows ? 'dummy_test_exe.bat' : 'dummy_test_exe.sh';
+      testExePath = p.join(tempDir.path, testExeName);
+
+      if (Platform.isWindows) {
+        await File(testExePath).writeAsString('@echo dummy_output');
+      } else {
+        final file = File(testExePath);
+        await file.writeAsString('#!/bin/sh\necho dummy_output\n');
+        // Make it executable
+        await Process.run('chmod', ['+x', testExePath]);
+      }
+
+      customEnv = {
+        'PATH': tempDir.path,
+      };
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('find returns null if not in parent environment and includeParentEnvironment is false', () async {
+      final exe = Executable(testExeName);
+      final path = await exe.find(environment: {}, includeParentEnvironment: false);
+      expect(path, isNull);
+    });
+
+    test('findSync returns null if not in parent environment and includeParentEnvironment is false', () {
+      final exe = Executable(testExeName);
+      final path = exe.findSync(environment: {}, includeParentEnvironment: false);
+      expect(path, isNull);
+    });
+
+    test('find uses custom environment PATH', () async {
+      final exe = Executable(testExeName);
+      final path = await exe.find(environment: customEnv, includeParentEnvironment: false);
+      expect(path, isNotNull);
+      expect(p.normalize(path!), p.normalize(testExePath));
+    });
+
+    test('findSync uses custom environment PATH', () {
+      final exe = Executable(testExeName);
+      final path = exe.findSync(environment: customEnv, includeParentEnvironment: false);
+      expect(path, isNotNull);
+      expect(p.normalize(path!), p.normalize(testExePath));
+    });
+
+    test('run executes successfully with custom environment', () async {
+      final exe = Executable(testExeName);
+      final result = await exe.run(
+        [],
+        environment: customEnv,
+        includeParentEnvironment: false,
+      );
+      expect(result.exitCode, 0);
+      expect(result.stdout.toString().trim(), 'dummy_output');
+    });
+
+    test('runSync executes successfully with custom environment', () {
+      final exe = Executable(testExeName);
+      final result = exe.runSync(
+        [],
+        environment: customEnv,
+        includeParentEnvironment: false,
+      );
+      expect(result.exitCode, 0);
+      expect(result.stdout.toString().trim(), 'dummy_output');
+    });
+
+    test('exists and existsSync work with custom environment', () async {
+      final exe = Executable(testExeName);
+
+      expect(await exe.exists(environment: customEnv, includeParentEnvironment: false), isTrue);
+      expect(exe.existsSync(environment: customEnv, includeParentEnvironment: false), isTrue);
+
+      expect(await exe.exists(environment: {}, includeParentEnvironment: false), isFalse);
+      expect(exe.existsSync(environment: {}, includeParentEnvironment: false), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Esta melhoria garante que executáveis disponíveis em PATHs fornecidos diretamente via `environment` (e não apenas no ambiente pai do Dart) sejam corretamente encontrados e executados através dos métodos `run` e `runSync` da classe `Executable`. Foi assegurado que cenários com custom environment previnam problemas de poluição do cache estático. A solução inclui um novo conjunto de testes unitários que cobre integralmente o repasse de parâmetros.

---
*PR created automatically by Jules for task [2704197754849085430](https://jules.google.com/task/2704197754849085430) started by @insign*