### PR TITLE
Executable agora usa environment de forma segura em métodos de resolução (find/exists)

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -15,8 +15,13 @@ class Executable {
       cmd.contains('/') || (Platform.isWindows && cmd.contains('\\'));
 
   /// Asynchronously finds the path to the executable [cmd].
-  Future<String?> find({bool ignoreCache = false}) async {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  Future<String?> find({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async {
+    final useCache = !ignoreCache && environment == null;
+    if (useCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -34,18 +39,38 @@ class Executable {
       }
     }
 
-    result ??= await which(cmd);
-    _whichResults[cmd] = result;
+    result ??= await which(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+
+    if (useCache) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Asynchronously checks if the executable [cmd] exists.
-  Future<bool> exists({bool ignoreCache = false}) async =>
-      await find(ignoreCache: ignoreCache) != null;
+  Future<bool> exists({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async =>
+      await find(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) != null;
 
   /// Synchronously finds the path to the executable [cmd].
-  String? findSync({bool ignoreCache = false}) {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  String? findSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) {
+    final useCache = !ignoreCache && environment == null;
+    if (useCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -63,14 +88,29 @@ class Executable {
       }
     }
 
-    result ??= whichSync(cmd);
-    _whichResults[cmd] = result;
+    result ??= whichSync(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+
+    if (useCache) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Synchronously checks if the executable [cmd] exists.
-  bool existsSync({bool ignoreCache = false}) =>
-      findSync(ignoreCache: ignoreCache) != null;
+  bool existsSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) =>
+      findSync(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) != null;
 
   /// Asynchronously runs the executable with the given [arguments].
   Future<ProcessResult> run(
@@ -82,7 +122,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) async {
-    final path = await find();
+    final path = await find(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }
@@ -109,7 +152,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) {
-    final path = findSync();
+    final path = findSync(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -45,4 +45,49 @@ void main() {
       throwsA(isA<ProcessException>()),
     );
   });
+
+  test('Test executable environment override', () async {
+    // Test that find() resolves an executable when provided a custom PATH
+    // and doesn't poison the cache for subsequent calls without environment.
+    final tempDir = await Directory.systemTemp.createTemp('executable_env_test_');
+    addTearDown(() => tempDir.delete(recursive: true));
+
+    var cmdName = 'custom_env_cmd';
+    if (Platform.isWindows) {
+      cmdName += '.bat';
+    }
+
+    final exePath = '${tempDir.path}${Platform.pathSeparator}$cmdName';
+    final file = File(exePath);
+    if (Platform.isWindows) {
+      await file.writeAsString('@echo off\necho hello');
+    } else {
+      await file.writeAsString('#!/bin/sh\necho hello');
+      await Process.run('chmod', ['+x', exePath]);
+    }
+
+    final executable = Executable('custom_env_cmd');
+
+    // Should not exist in normal environment
+    final normalFind = await executable.find();
+    expect(normalFind, isNull);
+
+    // Provide custom PATH
+    final separator = Platform.isWindows ? ';' : ':';
+    final envPath = Platform.environment['PATH'] ?? '';
+    final newPath = '${tempDir.path}$separator$envPath';
+    final customEnv = {...Platform.environment, 'PATH': newPath};
+
+    // Should find with custom environment
+    final envFind = await executable.find(environment: customEnv);
+    expect(envFind, isNotNull);
+
+    // Test synchronous method as well
+    final envFindSync = executable.findSync(environment: customEnv);
+    expect(envFindSync, isNotNull);
+
+    // Should still not exist in normal environment after custom env call
+    final normalFindAfter = await executable.find();
+    expect(normalFindAfter, isNull);
+  });
 }


### PR DESCRIPTION
O problema analisado encontrava-se na classe `Executable`, onde os métodos de execução `run` e `runSync` aceitavam um mapa de `environment` mas a resolução prévia do executável em `find` e `findSync` ignoravam este parâmetro. Assim, não era possível localizar um executável via `Executable.run` caso o seu caminho estivesse providenciado estritamente via a váriavel de ambiente customizada.

Esta alteração corrige este problema propagando os argumentos opcionais de `environment` até as buscas feitas com `process_run/which.dart`, ignorando o cache interno se o argumento for fornecido, a fim de evitar cache poisoning. Além disso, foram adicionados testes completos demonstrando a viabilidade desta feature. Apenas uma melhoria foi abordada conforme requerido.

---
*PR created automatically by Jules for task [7057892154846026154](https://jules.google.com/task/7057892154846026154) started by @insign*