### PR TITLE
feat: Suporte a ambientes customizados na busca por executáveis

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -15,8 +15,13 @@ class Executable {
       cmd.contains('/') || (Platform.isWindows && cmd.contains('\\'));
 
   /// Asynchronously finds the path to the executable [cmd].
-  Future<String?> find({bool ignoreCache = false}) async {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  Future<String?> find({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async {
+    final useCache = !ignoreCache && environment == null;
+    if (useCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -34,18 +39,38 @@ class Executable {
       }
     }
 
-    result ??= await which(cmd);
-    _whichResults[cmd] = result;
+    result ??= await which(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+    if (useCache) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Asynchronously checks if the executable [cmd] exists.
-  Future<bool> exists({bool ignoreCache = false}) async =>
-      await find(ignoreCache: ignoreCache) != null;
+  Future<bool> exists({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async =>
+      await find(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) !=
+      null;
 
   /// Synchronously finds the path to the executable [cmd].
-  String? findSync({bool ignoreCache = false}) {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  String? findSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) {
+    final useCache = !ignoreCache && environment == null;
+    if (useCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -63,14 +88,29 @@ class Executable {
       }
     }
 
-    result ??= whichSync(cmd);
-    _whichResults[cmd] = result;
+    result ??= whichSync(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+    if (useCache) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Synchronously checks if the executable [cmd] exists.
-  bool existsSync({bool ignoreCache = false}) =>
-      findSync(ignoreCache: ignoreCache) != null;
+  bool existsSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) =>
+      findSync(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) !=
+      null;
 
   /// Asynchronously runs the executable with the given [arguments].
   Future<ProcessResult> run(
@@ -82,7 +122,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) async {
-    final path = await find();
+    final path = await find(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }
@@ -109,7 +152,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) {
-    final path = findSync();
+    final path = findSync(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }

--- a/test/executable_environment_test.dart
+++ b/test/executable_environment_test.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:executable/executable.dart';
+
+void main() {
+  test('Test find with custom environment', () async {
+    final tempDir = await Directory.systemTemp.createTemp(
+      'executable_env_test_',
+    );
+    addTearDown(() => tempDir.delete(recursive: true));
+
+    var cmdName = 'dummy_env_cmd';
+    if (Platform.isWindows) {
+      cmdName += '.bat';
+    }
+
+    final exePath = '${tempDir.path}${Platform.pathSeparator}$cmdName';
+    final file = File(exePath);
+    if (Platform.isWindows) {
+      await file.writeAsString('@echo off\necho hello');
+    } else {
+      await file.writeAsString('#!/bin/sh\necho hello');
+      await Process.run('chmod', ['+x', exePath]);
+    }
+
+    final exe = Executable('dummy_env_cmd');
+
+    // Should not find it without custom env
+    final pathWithoutEnv = await exe.find(ignoreCache: true);
+    expect(pathWithoutEnv, isNull);
+
+    // Should find it with custom env
+    final customEnv = {'PATH': tempDir.path};
+    final pathWithEnv = await exe.find(
+      environment: customEnv,
+      includeParentEnvironment: false,
+    );
+    expect(pathWithEnv, isNotNull);
+
+    // Sync should behave similarly
+    final pathSyncWithoutEnv = exe.findSync(ignoreCache: true);
+    expect(pathSyncWithoutEnv, isNull);
+
+    final pathSyncWithEnv = exe.findSync(
+      environment: customEnv,
+      includeParentEnvironment: false,
+    );
+    expect(pathSyncWithEnv, isNotNull);
+
+    // Verify cache poisoning doesn't happen
+    final cachedPath = await exe.find();
+    expect(cachedPath, isNull);
+  });
+}


### PR DESCRIPTION
Neste Pull Request, introduzimos suporte a passagem de variáveis de ambiente customizadas para os métodos de busca na classe `Executable`. Anteriormente, os métodos `run` e `runSync` suportavam o parâmetro `environment`, porém a resolução do caminho do executável (através de `find` e `findSync`) não os utilizava, podendo falhar caso um executável residisse unicamente na variável `PATH` informada no argumento customizado.

Alterações:
1. Os parâmetros `environment` e `includeParentEnvironment` foram adicionados a `find`, `findSync`, `exists` e `existsSync`.
2. A utilização de cache foi desabilitada temporariamente caso um `environment` customizado seja providenciado, visando não poluir o cache unificado para todo o sistema de classes estáticas.
3. Testes unitários foram adicionados em `test/executable_environment_test.dart` para validar o comportamento dos métodos sincrônicos e assíncronos.

---
*PR created automatically by Jules for task [3144360848187108074](https://jules.google.com/task/3144360848187108074) started by @insign*