### PR TITLE
feat: suportar busca e resolucao via enviroment customizado

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -15,8 +15,13 @@ class Executable {
       cmd.contains('/') || (Platform.isWindows && cmd.contains('\\'));
 
   /// Asynchronously finds the path to the executable [cmd].
-  Future<String?> find({bool ignoreCache = false}) async {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  Future<String?> find({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async {
+    final bypassCache = ignoreCache || environment != null;
+    if (!bypassCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -34,18 +39,37 @@ class Executable {
       }
     }
 
-    result ??= await which(cmd);
-    _whichResults[cmd] = result;
+    result ??= await which(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+    if (!bypassCache) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Asynchronously checks if the executable [cmd] exists.
-  Future<bool> exists({bool ignoreCache = false}) async =>
-      await find(ignoreCache: ignoreCache) != null;
+  Future<bool> exists({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async =>
+      await find(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) != null;
 
   /// Synchronously finds the path to the executable [cmd].
-  String? findSync({bool ignoreCache = false}) {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  String? findSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) {
+    final bypassCache = ignoreCache || environment != null;
+    if (!bypassCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -63,14 +87,28 @@ class Executable {
       }
     }
 
-    result ??= whichSync(cmd);
-    _whichResults[cmd] = result;
+    result ??= whichSync(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+    if (!bypassCache) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Synchronously checks if the executable [cmd] exists.
-  bool existsSync({bool ignoreCache = false}) =>
-      findSync(ignoreCache: ignoreCache) != null;
+  bool existsSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) =>
+      findSync(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) != null;
 
   /// Asynchronously runs the executable with the given [arguments].
   Future<ProcessResult> run(
@@ -82,7 +120,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) async {
-    final path = await find();
+    final path = await find(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }
@@ -109,7 +150,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) {
-    final path = findSync();
+    final path = findSync(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }

--- a/test/executable_env_test.dart
+++ b/test/executable_env_test.dart
@@ -1,0 +1,119 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:executable/executable.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('Executable with custom environment', () {
+    late Directory tempDir;
+    late File dummyExecutable;
+    late String pathVarName;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('executable_env_test');
+      dummyExecutable = File(p.join(tempDir.path, 'my_dummy_command'));
+
+      // Criar um script "falso" para ser um executável
+      if (Platform.isWindows) {
+        dummyExecutable = File('${dummyExecutable.path}.bat');
+        await dummyExecutable.writeAsString('@echo off\necho dummy');
+      } else {
+        await dummyExecutable.writeAsString('#!/bin/sh\necho dummy');
+        // Tornar executável
+        await Process.run('chmod', ['+x', dummyExecutable.path]);
+      }
+
+      pathVarName = Platform.isWindows ? 'Path' : 'PATH';
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('find returns correct path when custom environment is provided', () async {
+      final cmdName = p.basename(dummyExecutable.path);
+      final exec = Executable(cmdName);
+
+      // Com o ambiente padrão, não deve ser encontrado
+      expect(await exec.find(), isNull);
+
+      // Com o PATH alterado, deve ser encontrado
+      final customEnv = {pathVarName: tempDir.path};
+      final foundPath = await exec.find(
+        environment: customEnv,
+        includeParentEnvironment: true,
+      );
+
+      expect(foundPath, isNotNull);
+      expect(p.normalize(foundPath!), p.normalize(dummyExecutable.absolute.path));
+    });
+
+    test('findSync returns correct path when custom environment is provided', () {
+      final cmdName = p.basename(dummyExecutable.path);
+      final exec = Executable(cmdName);
+
+      expect(exec.findSync(), isNull);
+
+      final customEnv = {pathVarName: tempDir.path};
+      final foundPath = exec.findSync(
+        environment: customEnv,
+        includeParentEnvironment: true,
+      );
+
+      expect(foundPath, isNotNull);
+      expect(p.normalize(foundPath!), p.normalize(dummyExecutable.absolute.path));
+    });
+
+    test('custom environment bypasses cache', () async {
+      final cmdName = p.basename(dummyExecutable.path);
+      final exec = Executable(cmdName);
+
+      // A chamada sem cache_bypass salva null no cache
+      expect(await exec.find(), isNull);
+
+      final customEnv = {pathVarName: tempDir.path};
+      // A chamada com environment deve ignorar o null salvo e realizar uma nova busca
+      final foundPath = await exec.find(
+        environment: customEnv,
+        includeParentEnvironment: true,
+      );
+
+      expect(foundPath, isNotNull);
+    });
+
+    test('run successfully uses custom environment', () async {
+      final cmdName = p.basename(dummyExecutable.path);
+      final exec = Executable(cmdName);
+
+      final customEnv = {pathVarName: tempDir.path};
+
+      final result = await exec.run(
+        [],
+        environment: customEnv,
+        includeParentEnvironment: true,
+      );
+
+      expect(result.exitCode, 0);
+      expect(result.stdout.toString().trim(), 'dummy');
+    });
+
+    test('runSync successfully uses custom environment', () {
+      final cmdName = p.basename(dummyExecutable.path);
+      final exec = Executable(cmdName);
+
+      final customEnv = {pathVarName: tempDir.path};
+
+      final result = exec.runSync(
+        [],
+        environment: customEnv,
+        includeParentEnvironment: true,
+      );
+
+      expect(result.exitCode, 0);
+      expect(result.stdout.toString().trim(), 'dummy');
+    });
+  });
+}


### PR DESCRIPTION
Esta PR adiciona a possibilidade de injetar variáveis de ambiente e regras de hierarquia customizadas na hora de buscar ou executar os executáveis (ex: injetando um `PATH` próprio).

A atualização abrange a lógica assíncrona e síncrona.
Além disso, se houver um ambiente injetado, o cache das resoluções é intencionalmente pulado (`bypassCache`), garantindo que a execução não cause poluição ou envenenamento de cache por variáveis alheias. 

Testes robustos de compatibilidade (para `.bat` e scripts shell) garantem o comportamento em diferentes plataformas.

---
*PR created automatically by Jules for task [6556206337532478844](https://jules.google.com/task/6556206337532478844) started by @insign*