### PR TITLE
feat: suporte a environment customizado na busca do Executable

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -15,8 +15,13 @@ class Executable {
       cmd.contains('/') || (Platform.isWindows && cmd.contains('\\'));
 
   /// Asynchronously finds the path to the executable [cmd].
-  Future<String?> find({bool ignoreCache = false}) async {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  Future<String?> find({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async {
+    final bypassCache = ignoreCache || environment != null;
+    if (!bypassCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -34,18 +39,39 @@ class Executable {
       }
     }
 
-    result ??= await which(cmd);
-    _whichResults[cmd] = result;
+    result ??= await which(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+
+    if (!bypassCache) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Asynchronously checks if the executable [cmd] exists.
-  Future<bool> exists({bool ignoreCache = false}) async =>
-      await find(ignoreCache: ignoreCache) != null;
+  Future<bool> exists({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async =>
+      await find(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) !=
+      null;
 
   /// Synchronously finds the path to the executable [cmd].
-  String? findSync({bool ignoreCache = false}) {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  String? findSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) {
+    final bypassCache = ignoreCache || environment != null;
+    if (!bypassCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -63,14 +89,30 @@ class Executable {
       }
     }
 
-    result ??= whichSync(cmd);
-    _whichResults[cmd] = result;
+    result ??= whichSync(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+
+    if (!bypassCache) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Synchronously checks if the executable [cmd] exists.
-  bool existsSync({bool ignoreCache = false}) =>
-      findSync(ignoreCache: ignoreCache) != null;
+  bool existsSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) =>
+      findSync(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) !=
+      null;
 
   /// Asynchronously runs the executable with the given [arguments].
   Future<ProcessResult> run(
@@ -82,7 +124,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) async {
-    final path = await find();
+    final path = await find(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }
@@ -109,7 +154,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) {
-    final path = findSync();
+    final path = findSync(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -45,4 +45,50 @@ void main() {
       throwsA(isA<ProcessException>()),
     );
   });
+
+  test('Test executable with custom environment', () async {
+    final tempDir = Directory.systemTemp.createTempSync('exec_test');
+    final tempFile = File('${tempDir.path}/my_dummy_exec');
+    tempFile.writeAsStringSync('#!/bin/sh\necho "dummy"');
+
+    // Make it executable on POSIX systems
+    if (!Platform.isWindows) {
+      Process.runSync('chmod', ['+x', tempFile.path]);
+    }
+
+    final exec = Executable('my_dummy_exec');
+
+    // Without custom environment, it should fail
+    await expectLater(
+      () => exec.run([], includeParentEnvironment: false),
+      throwsA(isA<ProcessException>()),
+    );
+
+    // With custom environment containing tempDir in PATH, it should succeed
+    final env = {'PATH': tempDir.path};
+
+    if (!Platform.isWindows) {
+      final result = await exec.run(
+        [],
+        environment: env,
+        includeParentEnvironment: false,
+      );
+      expect(result.exitCode, 0);
+      expect(result.stdout.toString().trim(), 'dummy');
+    }
+
+    // Synchronous execution test
+    if (!Platform.isWindows) {
+      final resultSync = exec.runSync(
+        [],
+        environment: env,
+        includeParentEnvironment: false,
+      );
+      expect(resultSync.exitCode, 0);
+      expect(resultSync.stdout.toString().trim(), 'dummy');
+    }
+
+    // Clean up
+    tempDir.deleteSync(recursive: true);
+  });
 }


### PR DESCRIPTION
Permitir a execução e busca de binários usando ambientes controlados.

Antes dessa melhoria, quando o usuário tentava rodar o `.run` e `.runSync` com um dicionário de propriedades `environment` (que poderia conter um `PATH` customizado), as funções falhavam, pois o `.find` interno buscava apenas as propriedades globais do sistema.

Essa alteração faz com que o `.find`, `.findSync`, `.exists` e `.existsSync` aceitem parâmetros de ambiente customizados. Ademais, ele passa a repassar esses argumentos caso explicitados pelo `.run` e `.runSync` em vez de gerar exceção de binário não encontrado. Tudo está garantido contra envonamento de cache estático.

---
*PR created automatically by Jules for task [15455684575334674073](https://jules.google.com/task/15455684575334674073) started by @insign*