### PR TITLE
feat: support custom environment in Executable find and exists methods

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -15,8 +15,13 @@ class Executable {
       cmd.contains('/') || (Platform.isWindows && cmd.contains('\\'));
 
   /// Asynchronously finds the path to the executable [cmd].
-  Future<String?> find({bool ignoreCache = false}) async {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  Future<String?> find({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async {
+    final hasEnv = environment != null;
+    if (!ignoreCache && !hasEnv && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -25,7 +30,11 @@ class Executable {
       final file = File(cmd);
       if (await file.exists()) {
         if (Platform.isWindows) {
-          if (_isWindowsExecutable(cmd)) {
+          if (_isWindowsExecutable(
+            cmd,
+            environment: environment,
+            includeParentEnvironment: includeParentEnvironment,
+          )) {
             result = file.absolute.path;
           }
         } else if (await _isPosixExecutable(file)) {
@@ -34,18 +43,38 @@ class Executable {
       }
     }
 
-    result ??= await which(cmd);
-    _whichResults[cmd] = result;
+    result ??= await which(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+    if (!hasEnv) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Asynchronously checks if the executable [cmd] exists.
-  Future<bool> exists({bool ignoreCache = false}) async =>
-      await find(ignoreCache: ignoreCache) != null;
+  Future<bool> exists({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async =>
+      await find(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) !=
+      null;
 
   /// Synchronously finds the path to the executable [cmd].
-  String? findSync({bool ignoreCache = false}) {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  String? findSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) {
+    final hasEnv = environment != null;
+    if (!ignoreCache && !hasEnv && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -54,7 +83,11 @@ class Executable {
       final file = File(cmd);
       if (file.existsSync()) {
         if (Platform.isWindows) {
-          if (_isWindowsExecutable(cmd)) {
+          if (_isWindowsExecutable(
+            cmd,
+            environment: environment,
+            includeParentEnvironment: includeParentEnvironment,
+          )) {
             result = file.absolute.path;
           }
         } else if (_isPosixExecutableSync(file)) {
@@ -63,14 +96,29 @@ class Executable {
       }
     }
 
-    result ??= whichSync(cmd);
-    _whichResults[cmd] = result;
+    result ??= whichSync(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+    if (!hasEnv) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Synchronously checks if the executable [cmd] exists.
-  bool existsSync({bool ignoreCache = false}) =>
-      findSync(ignoreCache: ignoreCache) != null;
+  bool existsSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) =>
+      findSync(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) !=
+      null;
 
   /// Asynchronously runs the executable with the given [arguments].
   Future<ProcessResult> run(
@@ -82,7 +130,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) async {
-    final path = await find();
+    final path = await find(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }
@@ -109,7 +160,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) {
-    final path = findSync();
+    final path = findSync(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }
@@ -126,8 +180,19 @@ class Executable {
     );
   }
 
-  bool _isWindowsExecutable(String path) {
-    final pathExt = Platform.environment['PATHEXT'] ?? '.EXE;.BAT;.CMD;.COM';
+  bool _isWindowsExecutable(
+    String path, {
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) {
+    String? pathExt;
+    if (environment != null && environment.containsKey('PATHEXT')) {
+      pathExt = environment['PATHEXT'];
+    } else if (includeParentEnvironment) {
+      pathExt = Platform.environment['PATHEXT'];
+    }
+    pathExt ??= '.EXE;.BAT;.CMD;.COM';
+
     final extensions = pathExt.split(';').where((ext) => ext.isNotEmpty);
     final upperPath = path.toUpperCase();
     return extensions.any((ext) => upperPath.endsWith(ext.toUpperCase()));

--- a/test/executable_environment_test.dart
+++ b/test/executable_environment_test.dart
@@ -1,0 +1,116 @@
+import 'dart:io';
+
+import 'package:executable/executable.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Executable custom environment', () {
+    late Directory tempDir;
+    late String executablePath;
+    late String scriptName;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('executable_env_test_');
+      scriptName = Platform.isWindows
+          ? 'custom_script.bat'
+          : 'custom_script.sh';
+      executablePath = '${tempDir.path}${Platform.pathSeparator}$scriptName';
+
+      final file = File(executablePath);
+      if (Platform.isWindows) {
+        await file.writeAsString('@echo off\necho hello from env');
+      } else {
+        await file.writeAsString('#!/bin/sh\necho hello from env');
+        await Process.run('chmod', ['+x', executablePath]);
+      }
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('finds executable with custom PATH environment', () async {
+      final executable = Executable(scriptName);
+
+      // Default env should fail
+      var found = await executable.find();
+      expect(found, isNull);
+
+      // Custom env should succeed
+      found = await executable.find(
+        environment: {'PATH': tempDir.path},
+        includeParentEnvironment: false,
+      );
+
+      expect(found, isNotNull);
+      expect(
+        File(found!).absolute.path,
+        equals(File(executablePath).absolute.path),
+      );
+
+      expect(
+        await executable.exists(
+          environment: {'PATH': tempDir.path},
+          includeParentEnvironment: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('findSync finds executable with custom PATH environment', () {
+      final executable = Executable(scriptName);
+
+      // Default env should fail
+      var found = executable.findSync();
+      expect(found, isNull);
+
+      // Custom env should succeed
+      found = executable.findSync(
+        environment: {'PATH': tempDir.path},
+        includeParentEnvironment: false,
+      );
+
+      expect(found, isNotNull);
+      expect(
+        File(found!).absolute.path,
+        equals(File(executablePath).absolute.path),
+      );
+
+      expect(
+        executable.existsSync(
+          environment: {'PATH': tempDir.path},
+          includeParentEnvironment: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('run successfully uses custom environment', () async {
+      final executable = Executable(scriptName);
+
+      final result = await executable.run(
+        [],
+        environment: {'PATH': tempDir.path},
+        includeParentEnvironment: false,
+      );
+
+      expect(result.exitCode, 0);
+      expect(result.stdout.toString().trim(), 'hello from env');
+    });
+
+    test('runSync successfully uses custom environment', () {
+      final executable = Executable(scriptName);
+
+      final result = executable.runSync(
+        [],
+        environment: {'PATH': tempDir.path},
+        includeParentEnvironment: false,
+      );
+
+      expect(result.exitCode, 0);
+      expect(result.stdout.toString().trim(), 'hello from env');
+    });
+  });
+}


### PR DESCRIPTION
Esta melhoria resolve uma falha crítica onde os métodos `run` e `runSync` aceitavam configurações de ambiente (`environment`), mas essas configurações nunca eram repassadas para o método `find()` que fazia a busca do caminho do executável na máquina. Como resultado, se um binário existisse apenas em uma variável `PATH` específica do ambiente e não do sistema hospedeiro, o pacote lançava uma `ProcessException` de `Executable not found` antes de executar, impossibilitando o uso de ferramentas isoladas ou conteinerizadas sob ambientes customizados.

Além de aplicar a modificação, foram implementadas as salvaguardas para o cache estático interno (`_whichResults`), que agora ignora e não sobrescreve os caminhos cacheados com aqueles encontrados (ou não) em escopos de ambiente limitados.

Um novo arquivo de testes `executable_environment_test.dart` foi adicionado e integrado à suíte de testes. Formatações e linting foram aprovados. Nenhum arquivo temporário foi deixado para trás.

---
*PR created automatically by Jules for task [1672005405579259171](https://jules.google.com/task/1672005405579259171) started by @insign*