### PR TITLE
Suportar custom environment map na resolução de executáveis

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -15,8 +15,13 @@ class Executable {
       cmd.contains('/') || (Platform.isWindows && cmd.contains('\\'));
 
   /// Asynchronously finds the path to the executable [cmd].
-  Future<String?> find({bool ignoreCache = false}) async {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  Future<String?> find({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async {
+    final useCache = !ignoreCache && environment == null;
+    if (useCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -34,18 +39,38 @@ class Executable {
       }
     }
 
-    result ??= await which(cmd);
-    _whichResults[cmd] = result;
+    result ??= await which(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+
+    if (useCache) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Asynchronously checks if the executable [cmd] exists.
-  Future<bool> exists({bool ignoreCache = false}) async =>
-      await find(ignoreCache: ignoreCache) != null;
+  Future<bool> exists({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async =>
+      await find(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) != null;
 
   /// Synchronously finds the path to the executable [cmd].
-  String? findSync({bool ignoreCache = false}) {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  String? findSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) {
+    final useCache = !ignoreCache && environment == null;
+    if (useCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -63,14 +88,29 @@ class Executable {
       }
     }
 
-    result ??= whichSync(cmd);
-    _whichResults[cmd] = result;
+    result ??= whichSync(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+
+    if (useCache) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Synchronously checks if the executable [cmd] exists.
-  bool existsSync({bool ignoreCache = false}) =>
-      findSync(ignoreCache: ignoreCache) != null;
+  bool existsSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) =>
+      findSync(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) != null;
 
   /// Asynchronously runs the executable with the given [arguments].
   Future<ProcessResult> run(
@@ -82,7 +122,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) async {
-    final path = await find();
+    final path = await find(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }
@@ -109,7 +152,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) {
-    final path = findSync();
+    final path = findSync(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -45,4 +45,56 @@ void main() {
       throwsA(isA<ProcessException>()),
     );
   });
+
+  test('Test executable with custom environment', () async {
+    final tempDir = await Directory.systemTemp.createTemp('executable_env_test_');
+    addTearDown(() => tempDir.delete(recursive: true));
+
+    var scriptName = 'custom_env_script';
+    if (Platform.isWindows) {
+      scriptName += '.bat';
+    }
+
+    final scriptPath = '${tempDir.path}${Platform.pathSeparator}$scriptName';
+    final file = File(scriptPath);
+
+    if (Platform.isWindows) {
+      await file.writeAsString('@echo off\necho custom_env');
+    } else {
+      await file.writeAsString('#!/bin/sh\necho custom_env');
+      await Process.run('chmod', ['+x', scriptPath]);
+    }
+
+    final executable = Executable('custom_env_script');
+
+    // Should not find the executable initially
+    expect(await executable.find(), isNull);
+    expect(executable.findSync(), isNull);
+
+    final separator = Platform.isWindows ? ';' : ':';
+    final currentPath = Platform.environment['PATH'] ?? '';
+    final envPath = '${tempDir.path}$separator$currentPath';
+
+    final customEnv = {'PATH': envPath};
+
+    // Should find the executable with custom environment
+    final foundPath = await executable.find(environment: customEnv);
+    expect(foundPath, isNotNull);
+
+    final foundSyncPath = executable.findSync(environment: customEnv);
+    expect(foundSyncPath, isNotNull);
+
+    // Verify cache is bypassed when using custom environment
+    expect(await executable.find(), isNull);
+    expect(executable.findSync(), isNull);
+
+    // Test running with custom environment
+    final resultAsync = await executable.run([], environment: customEnv);
+    expect(resultAsync.exitCode, 0);
+    expect(resultAsync.stdout.toString().trim(), 'custom_env');
+
+    final resultSync = executable.runSync([], environment: customEnv);
+    expect(resultSync.exitCode, 0);
+    expect(resultSync.stdout.toString().trim(), 'custom_env');
+  });
 }


### PR DESCRIPTION
Adicionado suporte para parâmetros de `environment` customizados nas funções `find`, `findSync`, `exists` e `existsSync` da classe `Executable`. Anteriormente o pacote oferecia os métodos `run` e `runSync` que aceitavam um mapa de `environment`, mas esses métodos chamavam internamente `find()` dependendo exclusivamente do PATH padrão do sistema. 

Se um usuário definisse um `environment` alterando o PATH para um ambiente de execução em `run`, o método falharia com `ProcessException` por não encontrar o executável na variável global.

Esta melhoria repassa os parâmetros `environment` e `includeParentEnvironment` corretamente para as funções de busca do pacote `process_run`. O mecanismo de cache foi ajustado para ser ignorado quando um `environment` customizado for fornecido a fim de evitar `cache poisoning`. Adicionados testes garantindo que o comportamento funciona sem interferências de cache.

---
*PR created automatically by Jules for task [15707525949505405685](https://jules.google.com/task/15707525949505405685) started by @insign*