### PR TITLE
Support custom environment in executable lookup

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -15,8 +15,14 @@ class Executable {
       cmd.contains('/') || (Platform.isWindows && cmd.contains('\\'));
 
   /// Asynchronously finds the path to the executable [cmd].
-  Future<String?> find({bool ignoreCache = false}) async {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  Future<String?> find({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async {
+    final shouldIgnoreCache = ignoreCache || environment != null;
+
+    if (!shouldIgnoreCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -34,18 +40,40 @@ class Executable {
       }
     }
 
-    result ??= await which(cmd);
-    _whichResults[cmd] = result;
+    result ??= await which(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+
+    if (!shouldIgnoreCache) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Asynchronously checks if the executable [cmd] exists.
-  Future<bool> exists({bool ignoreCache = false}) async =>
-      await find(ignoreCache: ignoreCache) != null;
+  Future<bool> exists({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) async =>
+      await find(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) !=
+      null;
 
   /// Synchronously finds the path to the executable [cmd].
-  String? findSync({bool ignoreCache = false}) {
-    if (!ignoreCache && _whichResults.containsKey(cmd)) {
+  String? findSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) {
+    final shouldIgnoreCache = ignoreCache || environment != null;
+
+    if (!shouldIgnoreCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
     }
 
@@ -63,14 +91,30 @@ class Executable {
       }
     }
 
-    result ??= whichSync(cmd);
-    _whichResults[cmd] = result;
+    result ??= whichSync(
+      cmd,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
+
+    if (!shouldIgnoreCache) {
+      _whichResults[cmd] = result;
+    }
     return result;
   }
 
   /// Synchronously checks if the executable [cmd] exists.
-  bool existsSync({bool ignoreCache = false}) =>
-      findSync(ignoreCache: ignoreCache) != null;
+  bool existsSync({
+    bool ignoreCache = false,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+  }) =>
+      findSync(
+        ignoreCache: ignoreCache,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+      ) !=
+      null;
 
   /// Asynchronously runs the executable with the given [arguments].
   Future<ProcessResult> run(
@@ -82,7 +126,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) async {
-    final path = await find();
+    final path = await find(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }
@@ -109,7 +156,10 @@ class Executable {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) {
-    final path = findSync();
+    final path = findSync(
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+    );
     if (path == null) {
       throw ProcessException(cmd, arguments, 'Executable not found.');
     }

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -45,4 +45,89 @@ void main() {
       throwsA(isA<ProcessException>()),
     );
   });
+
+  group('Custom environment tests', () {
+    late Directory tempDir;
+    late String scriptName;
+    late String executablePath;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('executable_env_test_');
+      scriptName = Platform.isWindows
+          ? 'custom_script.bat'
+          : 'custom_script.sh';
+      executablePath = '${tempDir.path}${Platform.pathSeparator}$scriptName';
+
+      final file = File(executablePath);
+      if (Platform.isWindows) {
+        await file.writeAsString('@echo off\necho custom_env');
+      } else {
+        await file.writeAsString('#!/bin/sh\necho custom_env');
+        await Process.run('chmod', ['+x', executablePath]);
+      }
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    Map<String, String> getCustomEnv() {
+      final separator = Platform.isWindows ? ';' : ':';
+      final envPath = Platform.environment['PATH'] ?? '';
+      return {
+        ...Platform.environment,
+        'PATH': '${tempDir.path}$separator$envPath',
+      };
+    }
+
+    test('Test executable find with custom environment', () async {
+      final exe = Executable(scriptName);
+
+      // Should not find it without custom env
+      expect(await exe.find(), isNull);
+
+      // Should find it with custom env
+      final found = await exe.find(environment: getCustomEnv());
+      expect(found, isNotNull);
+      expect(
+        File(found!).absolute.path,
+        equals(File(executablePath).absolute.path),
+      );
+    });
+
+    test('Test executable findSync with custom environment', () {
+      final exe = Executable(scriptName);
+
+      // Should not find it without custom env
+      expect(exe.findSync(), isNull);
+
+      // Should find it with custom env
+      final found = exe.findSync(environment: getCustomEnv());
+      expect(found, isNotNull);
+      expect(
+        File(found!).absolute.path,
+        equals(File(executablePath).absolute.path),
+      );
+    });
+
+    test('Test executable run with custom environment', () async {
+      final exe = Executable(scriptName);
+
+      // Run with custom environment
+      final result = await exe.run([], environment: getCustomEnv());
+      expect(result.exitCode, 0);
+      expect(result.stdout.toString().trim(), 'custom_env');
+    });
+
+    test('Test executable runSync with custom environment', () {
+      final exe = Executable(scriptName);
+
+      // Run with custom environment
+      final result = exe.runSync([], environment: getCustomEnv());
+      expect(result.exitCode, 0);
+      expect(result.stdout.toString().trim(), 'custom_env');
+    });
+  });
 }


### PR DESCRIPTION
Esta melhoria permite que os métodos da classe `Executable` (como `find`, `findSync`, `exists`, e `existsSync`) recebam os parâmetros `environment` e `includeParentEnvironment`. Antes dessa alteração, ao utilizar `run` e `runSync` passando um map customizado contendo, por exemplo, um novo `PATH`, a ferramenta falhava em localizar o arquivo porque os métodos de busca originais buscavam apenas no `PATH` do sistema.

Essa alteração foi implementada junto a um mecanismo de segurança para o cache: se um parâmetro customizado de `environment` for passado, o cache estático interno é evitado e não recebe novas atualizações nem os fornece de volta, evitando assim a intoxicação do cache geral. Novos testes também foram adicionados para validar essa funcionalidade tanto para os métodos síncronos quanto para os assíncronos. Todo o código temporário e gerado para debug foi removido, em conformidade com as orientações iniciais.

---
*PR created automatically by Jules for task [6528969269746878966](https://jules.google.com/task/6528969269746878966) started by @insign*