### PR TITLE
feat: adicionar ignoreCache na execução (run/runSync)

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -121,6 +121,7 @@ class Executable {
   /// Asynchronously runs the executable with the given [arguments].
   Future<ProcessResult> run(
     List<String> arguments, {
+    bool ignoreCache = false,
     String? workingDirectory,
     Map<String, String>? environment,
     bool includeParentEnvironment = true,
@@ -129,6 +130,7 @@ class Executable {
     Encoding? stderrEncoding = systemEncoding,
   }) async {
     final path = await find(
+      ignoreCache: ignoreCache,
       environment: environment,
       includeParentEnvironment: includeParentEnvironment,
     );
@@ -151,6 +153,7 @@ class Executable {
   /// Synchronously runs the executable with the given [arguments].
   ProcessResult runSync(
     List<String> arguments, {
+    bool ignoreCache = false,
     String? workingDirectory,
     Map<String, String>? environment,
     bool includeParentEnvironment = true,
@@ -159,6 +162,7 @@ class Executable {
     Encoding? stderrEncoding = systemEncoding,
   }) {
     final path = findSync(
+      ignoreCache: ignoreCache,
       environment: environment,
       includeParentEnvironment: includeParentEnvironment,
     );

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -46,6 +46,75 @@ void main() {
     );
   });
 
+  group('ignoreCache tests for run and runSync', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('executable_cache_test_');
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('run bypasses cache when ignoreCache is true', () async {
+      var scriptName = Platform.isWindows ? 'dummy.bat' : 'dummy.sh';
+      var exePath = '${tempDir.path}${Platform.pathSeparator}$scriptName';
+      var exe = Executable(exePath);
+
+      // 1. Initially it doesn't exist. Find it so it caches 'null'
+      var initialFound = await exe.find();
+      expect(initialFound, isNull);
+
+      // 2. Now create the executable
+      var file = File(exePath);
+      if (Platform.isWindows) {
+        await file.writeAsString('@echo off\necho ignore_cache_run');
+      } else {
+        await file.writeAsString('#!/bin/sh\necho ignore_cache_run');
+        await Process.run('chmod', ['+x', exePath]);
+      }
+
+      // 3. run without ignoreCache should throw ProcessException
+      // because find() reads from cache and returns null
+      await expectLater(() => exe.run([]), throwsA(isA<ProcessException>()));
+
+      // 4. run with ignoreCache: true should work
+      var result = await exe.run([], ignoreCache: true);
+      expect(result.exitCode, 0);
+      expect(result.stdout.toString().trim(), 'ignore_cache_run');
+    });
+
+    test('runSync bypasses cache when ignoreCache is true', () async {
+      var scriptName = Platform.isWindows ? 'dummy_sync.bat' : 'dummy_sync.sh';
+      var exePath = '${tempDir.path}${Platform.pathSeparator}$scriptName';
+      var exe = Executable(exePath);
+
+      // 1. Initially it doesn't exist. Find it so it caches 'null'
+      var initialFound = exe.findSync();
+      expect(initialFound, isNull);
+
+      // 2. Now create the executable
+      var file = File(exePath);
+      if (Platform.isWindows) {
+        await file.writeAsString('@echo off\necho ignore_cache_run_sync');
+      } else {
+        await file.writeAsString('#!/bin/sh\necho ignore_cache_run_sync');
+        await Process.run('chmod', ['+x', exePath]);
+      }
+
+      // 3. runSync without ignoreCache should throw ProcessException
+      expect(() => exe.runSync([]), throwsA(isA<ProcessException>()));
+
+      // 4. runSync with ignoreCache: true should work
+      var result = exe.runSync([], ignoreCache: true);
+      expect(result.exitCode, 0);
+      expect(result.stdout.toString().trim(), 'ignore_cache_run_sync');
+    });
+  });
+
   group('Cache poisoning tests', () {
     test('find cache bypasses when includeParentEnvironment is false', () async {
       final exe = Executable('ls');
@@ -164,5 +233,4 @@ void main() {
       expect(result.stdout.toString().trim(), 'custom_env');
     });
   });
-
 }


### PR DESCRIPTION
Este PR adiciona o parâmetro `ignoreCache` aos métodos `run` e `runSync`, permitindo que os desenvolvedores ignorem o cache de resolução de caminhos, o que é fundamental quando executáveis acabam de ser instalados ou disponibilizados no sistema.

**Melhoria Escolhida:**
Adição do parâmetro `ignoreCache` aos métodos `run` e `runSync` na classe `Executable`.

**Por que agrega valor real ao projeto:**
Esta mudança resolve uma falha na API (onde `find` e `existsSync` podiam ignorar o cache, mas as funções de execução direta não podiam). Sem isso, desenvolvedores que usavam a biblioteca enfrentavam falhas ao tentar executar programas que acabaram de baixar/instalar, já que o resultado `null` (ausência prévia do executável) ficava permanentemente cacheado. Isso melhora consideravelmente a confiabilidade da biblioteca e a Experiência do Desenvolvedor (DX).

**Arquivos Alterados:**
- `lib/src/executable_base.dart`: Inserção de `ignoreCache` com valor padrão `false` nas assinaturas de `run` e `runSync`, e repasse correto a `find` e `findSync`.
- `test/executable_test.dart`: Inclusão de um novo grupo de testes garantindo que ao usar `ignoreCache: true`, é possível descobrir e executar um binário que estava ausente na primeira busca.

**Atualizações em .md:**
Não houve atualizações em arquivos `.md`, pois o comportamento principal da biblioteca continua retrocompatível e os exemplos gerais do `README.md` não foram invalidados ou tornados incorretos.

**Impacto nos Testes:**
- Novos testes foram adicionados na suíte (`run bypasses cache when ignoreCache is true` e `runSync bypasses cache when ignoreCache is true`).
- A suíte original não foi alterada indevidamente e todos os 21 testes passaram sem falhas. A compatibilidade estrita foi mantida, uma vez que o novo parâmetro é opcional.

**Observações de Risco e Compatibilidade:**
- A modificação é totalmente compatível com o comportamento anterior, pois `ignoreCache` possui `false` como padrão, garantindo que usuários que não alterarem seu código fonte não sentirão diferença. Não adiciona dependências extras. Nenhuma regressão percebida.

---
*PR created automatically by Jules for task [7014622691571977252](https://jules.google.com/task/7014622691571977252) started by @insign*