### PR TITLE
feat: support workingDirectory for resolving relative executables

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -17,11 +17,15 @@ class Executable {
   /// Asynchronously finds the path to the executable [cmd].
   Future<String?> find({
     bool ignoreCache = false,
+    String? workingDirectory,
     Map<String, String>? environment,
     bool includeParentEnvironment = true,
   }) async {
     final shouldIgnoreCache =
-        ignoreCache || environment != null || !includeParentEnvironment;
+        ignoreCache ||
+        workingDirectory != null ||
+        environment != null ||
+        !includeParentEnvironment;
 
     if (!shouldIgnoreCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
@@ -29,7 +33,11 @@ class Executable {
 
     String? result;
     if (_isPath) {
-      final file = File(cmd);
+      String resolvedCmd = cmd;
+      if (workingDirectory != null && !File(cmd).isAbsolute) {
+        resolvedCmd = '$workingDirectory${Platform.pathSeparator}$cmd';
+      }
+      final file = File(resolvedCmd);
       if (await file.exists()) {
         if (Platform.isWindows) {
           if (_isWindowsExecutable(cmd)) {
@@ -56,11 +64,13 @@ class Executable {
   /// Asynchronously checks if the executable [cmd] exists.
   Future<bool> exists({
     bool ignoreCache = false,
+    String? workingDirectory,
     Map<String, String>? environment,
     bool includeParentEnvironment = true,
   }) async =>
       await find(
         ignoreCache: ignoreCache,
+        workingDirectory: workingDirectory,
         environment: environment,
         includeParentEnvironment: includeParentEnvironment,
       ) !=
@@ -69,11 +79,15 @@ class Executable {
   /// Synchronously finds the path to the executable [cmd].
   String? findSync({
     bool ignoreCache = false,
+    String? workingDirectory,
     Map<String, String>? environment,
     bool includeParentEnvironment = true,
   }) {
     final shouldIgnoreCache =
-        ignoreCache || environment != null || !includeParentEnvironment;
+        ignoreCache ||
+        workingDirectory != null ||
+        environment != null ||
+        !includeParentEnvironment;
 
     if (!shouldIgnoreCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
@@ -81,7 +95,11 @@ class Executable {
 
     String? result;
     if (_isPath) {
-      final file = File(cmd);
+      String resolvedCmd = cmd;
+      if (workingDirectory != null && !File(cmd).isAbsolute) {
+        resolvedCmd = '$workingDirectory${Platform.pathSeparator}$cmd';
+      }
+      final file = File(resolvedCmd);
       if (file.existsSync()) {
         if (Platform.isWindows) {
           if (_isWindowsExecutable(cmd)) {
@@ -108,11 +126,13 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({
     bool ignoreCache = false,
+    String? workingDirectory,
     Map<String, String>? environment,
     bool includeParentEnvironment = true,
   }) =>
       findSync(
         ignoreCache: ignoreCache,
+        workingDirectory: workingDirectory,
         environment: environment,
         includeParentEnvironment: includeParentEnvironment,
       ) !=
@@ -131,6 +151,7 @@ class Executable {
   }) async {
     final path = await find(
       ignoreCache: ignoreCache,
+      workingDirectory: workingDirectory,
       environment: environment,
       includeParentEnvironment: includeParentEnvironment,
     );
@@ -163,6 +184,7 @@ class Executable {
   }) {
     final path = findSync(
       ignoreCache: ignoreCache,
+      workingDirectory: workingDirectory,
       environment: environment,
       includeParentEnvironment: includeParentEnvironment,
     );

--- a/test/executable_test.dart
+++ b/test/executable_test.dart
@@ -233,4 +233,74 @@ void main() {
       expect(result.stdout.toString().trim(), 'custom_env');
     });
   });
+
+  group('workingDirectory tests', () {
+    late Directory tempDir;
+    late String scriptName;
+    late String relativeExecutablePath;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp(
+        'executable_workdir_test_',
+      );
+      scriptName = Platform.isWindows
+          ? 'workdir_script.bat'
+          : 'workdir_script.sh';
+      relativeExecutablePath = '.${Platform.pathSeparator}$scriptName';
+      final file = File('${tempDir.path}${Platform.pathSeparator}$scriptName');
+
+      if (Platform.isWindows) {
+        await file.writeAsString('@echo off\necho workdir_success');
+      } else {
+        await file.writeAsString('#!/bin/sh\necho workdir_success');
+        await Process.run('chmod', ['+x', file.path]);
+      }
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('Test find with workingDirectory', () async {
+      final exe = Executable(relativeExecutablePath);
+      final found = await exe.find(workingDirectory: tempDir.path);
+      expect(found, isNotNull);
+      expect(File(found!).existsSync(), isTrue);
+    });
+
+    test('Test findSync with workingDirectory', () {
+      final exe = Executable(relativeExecutablePath);
+      final found = exe.findSync(workingDirectory: tempDir.path);
+      expect(found, isNotNull);
+      expect(File(found!).existsSync(), isTrue);
+    });
+
+    test('Test exists with workingDirectory', () async {
+      final exe = Executable(relativeExecutablePath);
+      final exists = await exe.exists(workingDirectory: tempDir.path);
+      expect(exists, isTrue);
+    });
+
+    test('Test existsSync with workingDirectory', () {
+      final exe = Executable(relativeExecutablePath);
+      final exists = exe.existsSync(workingDirectory: tempDir.path);
+      expect(exists, isTrue);
+    });
+
+    test('Test run with workingDirectory', () async {
+      final exe = Executable(relativeExecutablePath);
+      final result = await exe.run([], workingDirectory: tempDir.path);
+      expect(result.exitCode, 0);
+      expect(result.stdout.toString().trim(), 'workdir_success');
+    });
+
+    test('Test runSync with workingDirectory', () {
+      final exe = Executable(relativeExecutablePath);
+      final result = exe.runSync([], workingDirectory: tempDir.path);
+      expect(result.exitCode, 0);
+      expect(result.stdout.toString().trim(), 'workdir_success');
+    });
+  });
 }


### PR DESCRIPTION
Adiciona suporte para resolução de executáveis relativos a um `workingDirectory` específico, corrigindo a falha em localizar scripts/binários fornecidos via caminhos relativos ao usar os métodos `.run()` ou `.runSync()` com diretório de trabalho alterado.

### Melhoria escolhida:
A melhoria consiste em injetar e respeitar o parâmetro `workingDirectory` durante a fase de busca (`find`, `findSync`, `exists`, `existsSync`) do binário e ao acionar a execução (`run`, `runSync`). 

### Por que agrega valor real ao projeto:
O Dart possui nativamente no `Process.run()` suporte à execução no escopo de um `workingDirectory`. Porém, a abstração atual de `Executable` interceptava o comando para procurá-lo localmente antes, e falhava ao usar o diretório de trabalho do processo pai ao invés de buscar no diretório onde o subprocesso seria rodado. Isso resolve um bug frustrante e alinha o comportamento da biblioteca com o do Dart IO nativo, melhorando substancialmente a confiabilidade.

### Arquivos alterados:
- `lib/src/executable_base.dart`: Lógica implementada repassando `workingDirectory`, resolvendo paths relativos anexados ao diretório, e ignorando o cache local.
- `test/executable_test.dart`: Criado um novo conjunto de testes sob o grupo `workingDirectory tests` para abranger e garantir os fluxos de caminho relativo usando o argumento tanto assincronamente quanto sincronicamente.

### Arquivos `.md` atualizados:
Nenhum arquivo `.md` foi atualizado pois a documentação existente não entra no nível de detalhe de APIs específicas de `Process.run` que tornem esta melhoria incorreta ou conflituosa com as instruções atuais no README.

### Impacto nos testes:
Testes executados com sucesso (`dart test`). Os testes existentes foram mantidos intocados, e novos testes validando a criação e resolução via `workingDirectory` em pastas temporárias foram adicionados para Linux e Windows.

### Observação importante sobre riscos:
Nenhum risco de compatibilidade para quem não usava `workingDirectory` com paths relativos. O cache continua operando de forma otimizada nos outros casos, sendo ignorado em caminhos por `workingDirectory` por razões de segurança e correção (para prevenir contaminação da tabela `_whichResults`). O comportamento para chamadas legadas ou com caminhos absolutos continua o mesmo.

---
*PR created automatically by Jules for task [1772969134516637528](https://jules.google.com/task/1772969134516637528) started by @insign*