### PR TITLE
feat: suportar a resolução de paths relativos a um `workingDirectory`

### DIFF
--- a/lib/src/executable_base.dart
+++ b/lib/src/executable_base.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
 import 'package:process_run/which.dart';
 
 /// A class for dealing with executables.
@@ -17,11 +18,15 @@ class Executable {
   /// Asynchronously finds the path to the executable [cmd].
   Future<String?> find({
     bool ignoreCache = false,
+    String? workingDirectory,
     Map<String, String>? environment,
     bool includeParentEnvironment = true,
   }) async {
     final shouldIgnoreCache =
-        ignoreCache || environment != null || !includeParentEnvironment;
+        ignoreCache ||
+        workingDirectory != null ||
+        environment != null ||
+        !includeParentEnvironment;
 
     if (!shouldIgnoreCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
@@ -29,10 +34,13 @@ class Executable {
 
     String? result;
     if (_isPath) {
-      final file = File(cmd);
+      final resolvedCmd = workingDirectory != null && !p.isAbsolute(cmd)
+          ? p.normalize(p.join(workingDirectory, cmd))
+          : p.normalize(cmd);
+      final file = File(resolvedCmd);
       if (await file.exists()) {
         if (Platform.isWindows) {
-          if (_isWindowsExecutable(cmd)) {
+          if (_isWindowsExecutable(resolvedCmd)) {
             result = file.absolute.path;
           }
         } else if (await _isPosixExecutable(file)) {
@@ -56,11 +64,13 @@ class Executable {
   /// Asynchronously checks if the executable [cmd] exists.
   Future<bool> exists({
     bool ignoreCache = false,
+    String? workingDirectory,
     Map<String, String>? environment,
     bool includeParentEnvironment = true,
   }) async =>
       await find(
         ignoreCache: ignoreCache,
+        workingDirectory: workingDirectory,
         environment: environment,
         includeParentEnvironment: includeParentEnvironment,
       ) !=
@@ -69,11 +79,15 @@ class Executable {
   /// Synchronously finds the path to the executable [cmd].
   String? findSync({
     bool ignoreCache = false,
+    String? workingDirectory,
     Map<String, String>? environment,
     bool includeParentEnvironment = true,
   }) {
     final shouldIgnoreCache =
-        ignoreCache || environment != null || !includeParentEnvironment;
+        ignoreCache ||
+        workingDirectory != null ||
+        environment != null ||
+        !includeParentEnvironment;
 
     if (!shouldIgnoreCache && _whichResults.containsKey(cmd)) {
       return _whichResults[cmd];
@@ -81,10 +95,13 @@ class Executable {
 
     String? result;
     if (_isPath) {
-      final file = File(cmd);
+      final resolvedCmd = workingDirectory != null && !p.isAbsolute(cmd)
+          ? p.normalize(p.join(workingDirectory, cmd))
+          : p.normalize(cmd);
+      final file = File(resolvedCmd);
       if (file.existsSync()) {
         if (Platform.isWindows) {
-          if (_isWindowsExecutable(cmd)) {
+          if (_isWindowsExecutable(resolvedCmd)) {
             result = file.absolute.path;
           }
         } else if (_isPosixExecutableSync(file)) {
@@ -108,11 +125,13 @@ class Executable {
   /// Synchronously checks if the executable [cmd] exists.
   bool existsSync({
     bool ignoreCache = false,
+    String? workingDirectory,
     Map<String, String>? environment,
     bool includeParentEnvironment = true,
   }) =>
       findSync(
         ignoreCache: ignoreCache,
+        workingDirectory: workingDirectory,
         environment: environment,
         includeParentEnvironment: includeParentEnvironment,
       ) !=
@@ -131,6 +150,7 @@ class Executable {
   }) async {
     final path = await find(
       ignoreCache: ignoreCache,
+      workingDirectory: workingDirectory,
       environment: environment,
       includeParentEnvironment: includeParentEnvironment,
     );
@@ -163,6 +183,7 @@ class Executable {
   }) {
     final path = findSync(
       ignoreCache: ignoreCache,
+      workingDirectory: workingDirectory,
       environment: environment,
       includeParentEnvironment: includeParentEnvironment,
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   sdk: '>=3.9.0 <4.0.0'
 
 dependencies:
+  path: ^1.9.1
   process_run: ^1.2.4
 
 dev_dependencies:

--- a/test/executable_full_path_test.dart
+++ b/test/executable_full_path_test.dart
@@ -84,9 +84,11 @@ void main() {
         final found = await executable.find();
 
         expect(found, isNotNull);
+        // Compare checking if the real paths are matching, since p.normalize removes './'
+        // and File('./').absolute retains it.
         expect(
-          File(found!).absolute.path,
-          equals(File(relativePath).absolute.path),
+          File(found!).resolveSymbolicLinksSync(),
+          equals(File(relativePath).absolute.resolveSymbolicLinksSync()),
         );
       } finally {
         Directory.current = originalCwd;

--- a/test/working_directory_test.dart
+++ b/test/working_directory_test.dart
@@ -1,0 +1,123 @@
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:executable/executable.dart';
+
+void main() {
+  group('workingDirectory support tests', () {
+    late Directory tempDir;
+    late String scriptName;
+    late String scriptPath;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('executable_wd_test_');
+      scriptName = Platform.isWindows ? 'local_script.bat' : 'local_script.sh';
+      scriptPath = '${tempDir.path}${Platform.pathSeparator}$scriptName';
+
+      final file = File(scriptPath);
+      if (Platform.isWindows) {
+        await file.writeAsString('@echo off\necho success');
+      } else {
+        await file.writeAsString('#!/bin/sh\necho success');
+        await Process.run('chmod', ['+x', scriptPath]);
+      }
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('find correctly resolves relative path using workingDirectory', () async {
+      final exe = Executable('./$scriptName');
+
+      // Sem workingDirectory o executável relativo não é encontrado (pois o CWD atual do processo de teste não tem o script)
+      expect(await exe.find(), isNull);
+
+      // Com workingDirectory ele deve encontrar e retornar o caminho absoluto correto do script criado
+      final found = await exe.find(workingDirectory: tempDir.path);
+      expect(found, isNotNull);
+      expect(
+        File(found!).absolute.path,
+        equals(File(scriptPath).absolute.path),
+      );
+    });
+
+    test(
+      'findSync correctly resolves relative path using workingDirectory',
+      () {
+        final exe = Executable('./$scriptName');
+
+        expect(exe.findSync(), isNull);
+
+        final found = exe.findSync(workingDirectory: tempDir.path);
+        expect(found, isNotNull);
+        expect(
+          File(found!).absolute.path,
+          equals(File(scriptPath).absolute.path),
+        );
+      },
+    );
+
+    test('exists and existsSync work with workingDirectory', () async {
+      final exe = Executable('./$scriptName');
+
+      expect(await exe.exists(), isFalse);
+      expect(exe.existsSync(), isFalse);
+
+      expect(await exe.exists(workingDirectory: tempDir.path), isTrue);
+      expect(exe.existsSync(workingDirectory: tempDir.path), isTrue);
+    });
+
+    test(
+      'run successfully executes relative executable using workingDirectory',
+      () async {
+        final exe = Executable('./$scriptName');
+
+        // run using workingDirectory
+        final result = await exe.run([], workingDirectory: tempDir.path);
+        expect(result.exitCode, 0);
+        expect(result.stdout.toString().trim(), 'success');
+      },
+    );
+
+    test(
+      'runSync successfully executes relative executable using workingDirectory',
+      () {
+        final exe = Executable('./$scriptName');
+
+        // runSync using workingDirectory
+        final result = exe.runSync([], workingDirectory: tempDir.path);
+        expect(result.exitCode, 0);
+        expect(result.stdout.toString().trim(), 'success');
+      },
+    );
+    test(
+      'find correctly resolves absolute path ignoring workingDirectory',
+      () async {
+        final exePath = Platform.isWindows
+            ? 'C:\\absolute\\path\\cmd.exe'
+            : '/absolute/path/cmd.sh';
+        final exe = Executable(exePath);
+
+        final found = await exe.find(workingDirectory: '/some/other/dir');
+        // If it tries to resolve, it would crash or create a malformed path.
+        // Since the path doesn't exist, it should return null safely without throwing UnsupportedError.
+        expect(found, isNull);
+      },
+    );
+
+    test(
+      'findSync correctly resolves absolute path ignoring workingDirectory',
+      () {
+        final exePath = Platform.isWindows
+            ? 'C:\\absolute\\path\\cmd.exe'
+            : '/absolute/path/cmd.sh';
+        final exe = Executable(exePath);
+
+        final found = exe.findSync(workingDirectory: '/some/other/dir');
+        expect(found, isNull);
+      },
+    );
+  });
+}


### PR DESCRIPTION
A adição do parâmetro `workingDirectory` permite que os métodos (`find`, `run`, etc.) resolvam caminhos relativos em relação ao diretório escolhido, e não ao diretório de trabalho do processo atual. Isso corrige o bug onde a resolução prévia tentava achar o executável no local errado quando uma pasta de destino diferente era fornecida nos comandos de execução.

Arquivos modificados:
- `pubspec.yaml`: adição da dependência `path`, estritamente necessária para tratamento seguro de caminhos cruzados sem provocar exceptions (como Uri fazia em SO Windows).
- `lib/src/executable_base.dart`: métodos da classe atualizados para suportar a resolução.
- `test/working_directory_test.dart` e `test/executable_full_path_test.dart`: adição e adequação de testes de regressão e suporte a funcionalidades.

Testes:
- Impacto positivo, garantindo o suporte do novo recurso bem como blindando paths absolutos via `p.isAbsolute()`. Testes ajustados para refletir o comportamento e novos testes dedicados adicionados. Nenhuma falha residual nas regressões.

Documentações:
- O `.md` principal não foi modificado por não ter partes explícitas de listagem completa de parâmetros (`find` e outros só aparecem em exemplos rudimentares que continuam consistentes e operantes).

---
*PR created automatically by Jules for task [13605811520931873836](https://jules.google.com/task/13605811520931873836) started by @insign*